### PR TITLE
Create imgur.css

### DIFF
--- a/styles/all/theme/css/imgur.css
+++ b/styles/all/theme/css/imgur.css
@@ -1,0 +1,8 @@
+/**
+ * Imgur Extension for phpBB.
+ * @author Alfredo Ramos <alfredo.ramos@yandex.com>
+ * @copyright 2017 Alfredo Ramos
+ * @license GNU GPL-2.0
+ */
+ 
+ /** Created to avoid crash. **/

--- a/styles/comboot/template/abbc3_imgur_posting_button.html
+++ b/styles/comboot/template/abbc3_imgur_posting_button.html
@@ -1,0 +1,4 @@
+/**Slightly edited by Regend Soh <https://bio.regend.xyz/>
+  */
+
+<input type="button" class="imgur-button abbc3_button" title="{{ lang('IMGUR_BUTTON_EXPLAIN') }}" />

--- a/styles/comboot/template/abbc3_imgur_posting_button.html
+++ b/styles/comboot/template/abbc3_imgur_posting_button.html
@@ -1,4 +1,5 @@
 /**Slightly edited by Regend Soh <https://bio.regend.xyz/>
+  *Credits to Alfredo Ramos <alfredo.ramos@yandex.com>
   */
 
 <input type="button" class="imgur-button abbc3_button" title="{{ lang('IMGUR_BUTTON_EXPLAIN') }}" />

--- a/styles/comboot/template/imgur_posting_button.html
+++ b/styles/comboot/template/imgur_posting_button.html
@@ -1,0 +1,7 @@
+/**Slightly edited by Regend Soh <https://bio.regend.xyz/>
+  *Credits to Alfredo Ramos <alfredo.ramos@yandex.com>
+  */
+
+<button type="button" class="imgur-button button button-icon-only bbcode-color" title="{{ lang('IMGUR_BUTTON_EXPLAIN') }}">
+	<span class="icon"></span>
+</button>

--- a/styles/comboot/theme/css/imgur.css
+++ b/styles/comboot/theme/css/imgur.css
@@ -1,0 +1,15 @@
+/**Slightly edited by Regend Soh <https://bio.regend.xyz/>
+  *Credits to Alfredo Ramos <alfredo.ramos@yandex.com>
+  */
+
+.imgur-button > .icon {
+	display: inline-block;
+  	width: 30px;
+ 	height: 30px;
+	background-image: url(../../../all/theme/images/imgur.svg);
+	
+}
+
+.imgur-button.abbc3_button {
+	background-image: url(../../../all/theme/images/imgur.svg);
+}


### PR DESCRIPTION
Created to avoid crash when an undefined theme in phpbb style folder is in used. Previously, new theme must be defined in imgur style folder, or inherits the prosilver theme(not tested) to avoid crashing.

However, after adding this file, users still need to create a folder named as same as the theme inside the style folder of imgur, with all the same files in prosilver. This is to ensure that the button will correctly display (with the imgur logo inside). 