### PR TITLE
Improve ACP output settings

### DIFF
--- a/adm/style/acp_imgur_output_settings.html
+++ b/adm/style/acp_imgur_output_settings.html
@@ -13,7 +13,7 @@
 <form id="imgur_output_settings" method="POST" action="{{ U_ACTION }}">
 
 	<div class="errorbox notice">
-		<p>{{ lang('ACP_IMGUR_OUTPUT_EXPLAIN') }}</p>
+		<p>{{ lang('ACP_IMGUR_OUTPUT_TYPE_EXPLAIN') }}</p>
 	</div>
 	<table id="imgur_output_list" class="table1 responsive zebra-table imgur-table">
 		<thead>

--- a/adm/style/acp_imgur_output_settings.html
+++ b/adm/style/acp_imgur_output_settings.html
@@ -10,7 +10,148 @@
 </div>
 {% endif %}
 
+<div class="errorbox notice">
+	<p>{{ lang('ACP_IMGUR_OUTPUT_EXPLAIN') }}</p>
+	<p>{{ lang('ACP_IMGUR_THUMBNAIL_SIZE_EXPLAIN') }}</p>
+</div>
+
 <form id="imgur_output_settings" method="POST" action="{{ U_ACTION }}">
+
+	<table id="imgur_output_list" class="table1 responsive zebra-table imgur-table">
+		<thead>
+			<tr>
+				<th>{{ lang('ACP_IMGUR_OUTPUT_TYPE') }}</th>
+				<th>{{ lang('ENABLED') }}</th>
+				<th>{{ lang('DEFAULT') }}</th>
+			</tr>
+		</thead>
+		<tbody>
+			{%- if IMGUR_OUTPUT_TYPES and IMGUR_OUTPUT_TYPES is iterable -%}
+
+			{% for OUTPUT_TYPE in IMGUR_OUTPUT_TYPES %}
+			<tr class="row-highlight">
+				<td>
+					<label for="imgur_output_type_{{ OUTPUT_TYPE.KEY }}">
+						<strong>{{ OUTPUT_TYPE.NAME }}</strong>
+					</label>
+					{% if OUTPUT_TYPE.EXPLAIN %}<br><span>{{ OUTPUT_TYPE.EXPLAIN }}</span>{% endif %}
+				</td>
+				<td class="actions">
+					<input type="checkbox" id="imgur_output_type_{{ OUTPUT_TYPE.KEY }}" name="imgur_enabled_output_types[]" value="{{ OUTPUT_TYPE.KEY }}"{% if OUTPUT_TYPE.ENABLED %} checked="checked"{% endif %}>
+				</td>
+				<td class="actions">
+					<input type="radio" name="imgur_output_type"{% if IMGUR_OUTPUT_TYPE is same as(OUTPUT_TYPE.KEY) %} checked="checked"{% endif %}>
+				</td>
+			</tr>
+			{% endfor %}
+
+			{%- else -%}
+			<tr class="big-column">
+				<td colspan="3" style="text-align: center;">{{ lang('ACP_NO_ITEMS') }}</td>
+			</tr>
+			{%- endif -%}
+		</tbody>
+	</table>
+	<fieldset class="quick">
+		<p class="small">
+		<a href="#" onclick="marklist('imgur_output_list', 'imgur_enabled_output_types', true)">{{ lang('MARK_ALL') }}</a> • <a href="#" onclick="marklist('imgur_output_list', 'imgur_enabled_output_types', false)">{{ lang('UNMARK_ALL') }}</a>
+		</p>
+	</fieldset>
+
+	<hr>
+
+	<table id="imgur_thumbnail_list" class="table1 responsive zebra-table imgur-table">
+		<thead>
+			<tr>
+				<th>{{ lang('ACP_IMGUR_THUMBNAIL_SIZE') }}</th>
+				<th>{{ lang('ENABLED') }}</th>
+				<th>{{ lang('DEFAULT') }}</th>
+			</tr>
+		</thead>
+		<tbody>
+			{%- set THUMBNAILS_NORMAL = IMGUR_THUMBNAIL_SIZES | filter(SIZE => SIZE.KEEP_PROPORTIONS is same as(true)) -%}
+			{%- set THUMBNAILS_SQUARE = IMGUR_THUMBNAIL_SIZES | filter(SIZE => SIZE.KEEP_PROPORTIONS is same as(false)) -%}
+			{%- if (THUMBNAILS_NORMAL and THUMBNAILS_NORMAL is iterable) or (THUMBNAILS_SQUARE and THUMBNAILS_SQUARE is iterable) -%}
+
+			{% if THUMBNAILS_NORMAL and THUMBNAILS_NORMAL is iterable %}
+			<tr class="big-column">
+				<td class="row3 row1" colspan="3">
+					<strong>{{ lang('ACP_IMGUR_THUMBNAIL_KEEP_PROPORTIONS') }}</strong>
+				</td>
+			</tr>
+			{% for THUMBNAIL_SIZE in THUMBNAILS_NORMAL %}
+			<tr class="row-highlight">
+				<td>
+					<label for="imgur_thumbnail_size_{{ THUMBNAIL_SIZE.KEY }}">
+						<strong>{{ THUMBNAIL_SIZE.NAME }}</strong>
+					</label>
+					{% if THUMBNAIL_SIZE.EXPLAIN %}<br><span>{{ THUMBNAIL_SIZE.EXPLAIN }}</span>{% endif %}
+				</td>
+				<td class="actions">
+					<input type="checkbox" id="imgur_thumbnail_size_{{ THUMBNAIL_SIZE.KEY }}" name="imgur_enabled_thumbnail_sizes[]" value="{{ THUMBNAIL_SIZE.KEY }}"{% if THUMBNAIL_SIZE.ENABLED %} checked="checked"{% endif %}>
+				</td>
+				<td class="actions">
+					<input type="radio" name="imgur_thumbnail_size"{% if IMGUR_THUMBNAIL_SIZE is same as(THUMBNAIL_SIZE.KEY) %} checked="checked"{% endif %}>
+				</td>
+			</tr>
+			{% endfor %}
+			{% endif %}
+
+			{% if THUMBNAILS_SQUARE and THUMBNAILS_SQUARE is iterable %}
+			<tr class="big-column">
+				<td class="row3 row1" colspan="3">
+					<strong>{{ lang('ACP_IMGUR_THUMBNAIL_NOT_KEEP_PROPORTIONS') }}</strong>
+				</td>
+			</tr>
+			{% for THUMBNAIL_SIZE in THUMBNAILS_SQUARE %}
+			<tr class="row-highlight">
+				<td>
+					<label for="imgur_thumbnail_size_{{ THUMBNAIL_SIZE.KEY }}">
+						<strong>{{ THUMBNAIL_SIZE.NAME }}</strong>
+					</label>
+					{% if THUMBNAIL_SIZE.EXPLAIN %}<br><span>{{ THUMBNAIL_SIZE.EXPLAIN }}</span>{% endif %}
+				</td>
+				<td class="actions">
+					<input type="checkbox" id="imgur_thumbnail_size_{{ THUMBNAIL_SIZE.KEY }}" name="imgur_enabled_thumbnail_sizes[]" value="{{ THUMBNAIL_SIZE.KEY }}"{% if THUMBNAIL_SIZE.ENABLED %} checked="checked"{% endif %}>
+				</td>
+				<td class="actions">
+					<input type="radio" name="imgur_thumbnail_size"{% if IMGUR_THUMBNAIL_SIZE is same as(THUMBNAIL_SIZE.KEY) %} checked="checked"{% endif %}>
+				</td>
+			</tr>
+			{% endfor %}
+			{% endif %}
+
+			{%- elseif IMGUR_THUMBNAIL_SIZES and IMGUR_THUMBNAIL_SIZES is iterable -%}
+
+			{% for THUMBNAIL_SIZE in IMGUR_THUMBNAIL_SIZES %}
+			<tr class="row-highlight">
+				<td>
+					<label for="imgur_thumbnail_size_{{ THUMBNAIL_SIZE.KEY }}">
+						<strong>{{ THUMBNAIL_SIZE.NAME }}</strong>
+					</label>
+					{% if THUMBNAIL_SIZE.EXPLAIN %}<br /><span>{{ THUMBNAIL_SIZE.EXPLAIN }}</span>{% endif %}
+				</td>
+				<td class="actions">
+					<input type="checkbox" id="imgur_thumbnail_size_{{ THUMBNAIL_SIZE.KEY }}" name="imgur_enabled_thumbnail_sizes[]" value="{{ THUMBNAIL_SIZE.KEY }}"{% if THUMBNAIL_SIZE.ENABLED %} checked="checked"{% endif %}>
+				</td>
+				<td class="actions">
+					<input type="radio" name="imgur_thumbnail_size"{% if IMGUR_THUMBNAIL_SIZE is same as(THUMBNAIL_SIZE.KEY) %} checked="checked"{% endif %}>
+				</td>
+			</tr>
+			{% endfor %}
+
+			{%- else -%}
+			<tr class="big-column">
+				<td colspan="3" style="text-align: center;">{{ lang('ACP_NO_ITEMS') }}</td>
+			</tr>
+			{%- endif -%}
+		</tbody>
+	</table>
+	<fieldset class="quick">
+		<p class="small">
+		<a href="#" onclick="marklist('imgur_thumbnail_list', 'imgur_enabled_thumbnail_sizes', true)">{{ lang('MARK_ALL') }}</a> • <a href="#" onclick="marklist('imgur_thumbnail_list', 'imgur_enabled_thumbnail_sizes', false)">{{ lang('UNMARK_ALL') }}</a>
+		</p>
+	</fieldset>
 
 	<fieldset>
 		<legend>{{ lang('OUTPUT_SETTINGS') }}</legend>

--- a/adm/style/acp_imgur_output_settings.html
+++ b/adm/style/acp_imgur_output_settings.html
@@ -64,7 +64,6 @@
 		<thead>
 			<tr>
 				<th>{{ lang('ACP_IMGUR_THUMBNAIL_SIZE') }}</th>
-				<th>{{ lang('ENABLED') }}</th>
 				<th>{{ lang('DEFAULT') }}</th>
 			</tr>
 		</thead>
@@ -88,9 +87,6 @@
 					{% if THUMBNAIL_SIZE.EXPLAIN %}<br><span>{{ THUMBNAIL_SIZE.EXPLAIN }}</span>{% endif %}
 				</td>
 				<td class="actions">
-					<input type="checkbox" id="imgur_thumbnail_size_{{ THUMBNAIL_SIZE.KEY }}" name="imgur_enabled_thumbnail_sizes[]" value="{{ THUMBNAIL_SIZE.KEY }}"{% if THUMBNAIL_SIZE.ENABLED %} checked="checked"{% endif %}>
-				</td>
-				<td class="actions">
 					<input type="radio" name="imgur_thumbnail_size" value="{{ THUMBNAIL_SIZE.KEY }}"{% if IMGUR_THUMBNAIL_SIZE is same as(THUMBNAIL_SIZE.KEY) %} checked="checked"{% endif %}>
 				</td>
 			</tr>
@@ -112,9 +108,6 @@
 					{% if THUMBNAIL_SIZE.EXPLAIN %}<br><span>{{ THUMBNAIL_SIZE.EXPLAIN }}</span>{% endif %}
 				</td>
 				<td class="actions">
-					<input type="checkbox" id="imgur_thumbnail_size_{{ THUMBNAIL_SIZE.KEY }}" name="imgur_enabled_thumbnail_sizes[]" value="{{ THUMBNAIL_SIZE.KEY }}"{% if THUMBNAIL_SIZE.ENABLED %} checked="checked"{% endif %}>
-				</td>
-				<td class="actions">
 					<input type="radio" name="imgur_thumbnail_size" value="{{ THUMBNAIL_SIZE.KEY }}"{% if IMGUR_THUMBNAIL_SIZE is same as(THUMBNAIL_SIZE.KEY) %} checked="checked"{% endif %}>
 				</td>
 			</tr>
@@ -132,9 +125,6 @@
 					{% if THUMBNAIL_SIZE.EXPLAIN %}<br /><span>{{ THUMBNAIL_SIZE.EXPLAIN }}</span>{% endif %}
 				</td>
 				<td class="actions">
-					<input type="checkbox" id="imgur_thumbnail_size_{{ THUMBNAIL_SIZE.KEY }}" name="imgur_enabled_thumbnail_sizes[]" value="{{ THUMBNAIL_SIZE.KEY }}"{% if THUMBNAIL_SIZE.ENABLED %} checked="checked"{% endif %}>
-				</td>
-				<td class="actions">
 					<input type="radio" name="imgur_thumbnail_size" value="{{ THUMBNAIL_SIZE.KEY }}"{% if IMGUR_THUMBNAIL_SIZE is same as(THUMBNAIL_SIZE.KEY) %} checked="checked"{% endif %}>
 				</td>
 			</tr>
@@ -147,11 +137,6 @@
 			{%- endif -%}
 		</tbody>
 	</table>
-	<fieldset class="quick">
-		<p class="small">
-		<a href="#" onclick="marklist('imgur_thumbnail_list', 'imgur_enabled_thumbnail_sizes', true)">{{ lang('MARK_ALL') }}</a> • <a href="#" onclick="marklist('imgur_thumbnail_list', 'imgur_enabled_thumbnail_sizes', false)">{{ lang('UNMARK_ALL') }}</a>
-		</p>
-	</fieldset>
 
 	<fieldset>
 		<legend>{{ lang('ACP_SUBMIT_CHANGES') }}</legend>

--- a/adm/style/acp_imgur_output_settings.html
+++ b/adm/style/acp_imgur_output_settings.html
@@ -40,7 +40,7 @@
 					<input type="checkbox" id="imgur_output_type_{{ OUTPUT_TYPE.KEY }}" name="imgur_enabled_output_types[]" value="{{ OUTPUT_TYPE.KEY }}"{% if OUTPUT_TYPE.ENABLED %} checked="checked"{% endif %}>
 				</td>
 				<td class="actions">
-					<input type="radio" name="imgur_output_type"{% if IMGUR_OUTPUT_TYPE is same as(OUTPUT_TYPE.KEY) %} checked="checked"{% endif %}>
+					<input type="radio" name="imgur_output_type" value="{{ OUTPUT_TYPE.KEY }}"{% if IMGUR_OUTPUT_TYPE is same as(OUTPUT_TYPE.KEY) %} checked="checked"{% endif %}>
 				</td>
 			</tr>
 			{% endfor %}
@@ -91,7 +91,7 @@
 					<input type="checkbox" id="imgur_thumbnail_size_{{ THUMBNAIL_SIZE.KEY }}" name="imgur_enabled_thumbnail_sizes[]" value="{{ THUMBNAIL_SIZE.KEY }}"{% if THUMBNAIL_SIZE.ENABLED %} checked="checked"{% endif %}>
 				</td>
 				<td class="actions">
-					<input type="radio" name="imgur_thumbnail_size"{% if IMGUR_THUMBNAIL_SIZE is same as(THUMBNAIL_SIZE.KEY) %} checked="checked"{% endif %}>
+					<input type="radio" name="imgur_thumbnail_size" value="{{ THUMBNAIL_SIZE.KEY }}"{% if IMGUR_THUMBNAIL_SIZE is same as(THUMBNAIL_SIZE.KEY) %} checked="checked"{% endif %}>
 				</td>
 			</tr>
 			{% endfor %}
@@ -115,7 +115,7 @@
 					<input type="checkbox" id="imgur_thumbnail_size_{{ THUMBNAIL_SIZE.KEY }}" name="imgur_enabled_thumbnail_sizes[]" value="{{ THUMBNAIL_SIZE.KEY }}"{% if THUMBNAIL_SIZE.ENABLED %} checked="checked"{% endif %}>
 				</td>
 				<td class="actions">
-					<input type="radio" name="imgur_thumbnail_size"{% if IMGUR_THUMBNAIL_SIZE is same as(THUMBNAIL_SIZE.KEY) %} checked="checked"{% endif %}>
+					<input type="radio" name="imgur_thumbnail_size" value="{{ THUMBNAIL_SIZE.KEY }}"{% if IMGUR_THUMBNAIL_SIZE is same as(THUMBNAIL_SIZE.KEY) %} checked="checked"{% endif %}>
 				</td>
 			</tr>
 			{% endfor %}
@@ -135,7 +135,7 @@
 					<input type="checkbox" id="imgur_thumbnail_size_{{ THUMBNAIL_SIZE.KEY }}" name="imgur_enabled_thumbnail_sizes[]" value="{{ THUMBNAIL_SIZE.KEY }}"{% if THUMBNAIL_SIZE.ENABLED %} checked="checked"{% endif %}>
 				</td>
 				<td class="actions">
-					<input type="radio" name="imgur_thumbnail_size"{% if IMGUR_THUMBNAIL_SIZE is same as(THUMBNAIL_SIZE.KEY) %} checked="checked"{% endif %}>
+					<input type="radio" name="imgur_thumbnail_size" value="{{ THUMBNAIL_SIZE.KEY }}"{% if IMGUR_THUMBNAIL_SIZE is same as(THUMBNAIL_SIZE.KEY) %} checked="checked"{% endif %}>
 				</td>
 			</tr>
 			{% endfor %}
@@ -151,36 +151,6 @@
 		<p class="small">
 		<a href="#" onclick="marklist('imgur_thumbnail_list', 'imgur_enabled_thumbnail_sizes', true)">{{ lang('MARK_ALL') }}</a> • <a href="#" onclick="marklist('imgur_thumbnail_list', 'imgur_enabled_thumbnail_sizes', false)">{{ lang('UNMARK_ALL') }}</a>
 		</p>
-	</fieldset>
-
-	<fieldset>
-		<legend>{{ lang('OUTPUT_SETTINGS') }}</legend>
-		<dl>
-			<dt>
-				<label for="imgur_output_type">{{ lang('ACP_IMGUR_OUTPUT_TYPE') }}{{ lang('COLON') }}</label>
-			</dt>
-			<dd>
-				<select id="imgur_output_type" name="imgur_output_type">
-					{% for OUTPUT_TYPE in IMGUR_OUTPUT_TYPES %}
-					<option value="{{ OUTPUT_TYPE.KEY }}"{% if IMGUR_OUTPUT_TYPE is same as(OUTPUT_TYPE.KEY) %} selected="selected"{% endif %}>{{ OUTPUT_TYPE.NAME }}</option>
-					{% endfor %}
-				</select>
-			</dd>
-		</dl>
-
-		<dl>
-			<dt>
-				<label for="imgur_thumbnail_size">{{ lang('ACP_IMGUR_THUMBNAIL_SIZE') }}{{ lang('COLON') }}</label>
-				<br><span>{{ lang('ACP_IMGUR_THUMBNAIL_SIZE_EXPLAIN') }}</span>
-			</dt>
-			<dd>
-				<select id="imgur_thumbnail_size" name="imgur_thumbnail_size">
-					{% for THUMBNAIL_SIZE in IMGUR_THUMBNAIL_SIZES %}
-					<option value="{{ THUMBNAIL_SIZE.KEY }}"{% if IMGUR_THUMBNAIL_SIZE is same as(THUMBNAIL_SIZE.KEY) %} selected="selected"{% endif %}>{{ THUMBNAIL_SIZE.NAME }}</option>
-					{% endfor %}
-				</select>
-			</dd>
-		</dl>
 	</fieldset>
 
 	<fieldset>

--- a/adm/style/acp_imgur_output_settings.html
+++ b/adm/style/acp_imgur_output_settings.html
@@ -10,13 +10,11 @@
 </div>
 {% endif %}
 
-<div class="errorbox notice">
-	<p>{{ lang('ACP_IMGUR_OUTPUT_EXPLAIN') }}</p>
-	<p>{{ lang('ACP_IMGUR_THUMBNAIL_SIZE_EXPLAIN') }}</p>
-</div>
-
 <form id="imgur_output_settings" method="POST" action="{{ U_ACTION }}">
 
+	<div class="errorbox notice">
+		<p>{{ lang('ACP_IMGUR_OUTPUT_EXPLAIN') }}</p>
+	</div>
 	<table id="imgur_output_list" class="table1 responsive zebra-table imgur-table">
 		<thead>
 			<tr>
@@ -60,6 +58,9 @@
 
 	<hr>
 
+	<div class="errorbox notice">
+		<p>{{ lang('ACP_IMGUR_THUMBNAIL_SIZE_EXPLAIN') }}</p>
+	</div>
 	<table id="imgur_thumbnail_list" class="table1 responsive zebra-table imgur-table">
 		<thead>
 			<tr>

--- a/adm/style/acp_imgur_output_settings.html
+++ b/adm/style/acp_imgur_output_settings.html
@@ -1,6 +1,7 @@
 {% include 'overall_header.html' %}
 
 <h1>{{ lang('OUTPUT_SETTINGS') }}</h1>
+{{ lang('OUTPUT_SETTINGS_EXPLAIN') }}
 
 {% if VALIDATION_ERRORS %}
 <div class="errorbox">
@@ -12,6 +13,8 @@
 
 <form id="imgur_output_settings" method="POST" action="{{ U_ACTION }}">
 
+	{%- set OUTPUT_TYPES_BUILTIN = IMGUR_OUTPUT_TYPES | filter(TYPE => TYPE.EXTRA is same as(false)) -%}
+	{%- set OUTPUT_TYPES_EXTRAS = IMGUR_OUTPUT_TYPES | filter(TYPE => TYPE.EXTRA is same as(true)) -%}
 	<div class="errorbox notice">
 		<p>{{ lang('ACP_IMGUR_OUTPUT_TYPE_EXPLAIN') }}</p>
 	</div>
@@ -24,7 +27,57 @@
 			</tr>
 		</thead>
 		<tbody>
-			{%- if IMGUR_OUTPUT_TYPES and IMGUR_OUTPUT_TYPES is iterable -%}
+		{%- if (OUTPUT_TYPES_BUILTIN and OUTPUT_TYPES_BUILTIN is iterable) or (OUTPUT_TYPES_EXTRAS and OUTPUT_TYPES_EXTRAS is iterable) -%}
+
+			{% if OUTPUT_TYPES_BUILTIN and OUTPUT_TYPES_BUILTIN is iterable %}
+			<tr class="big-column">
+				<td class="row3 row1" colspan="3">
+					<strong>{{ lang('ACP_IMGUR_OUTPUT_TYPE_BUILTIN') }}</strong>
+				</td>
+			</tr>
+			{% for OUTPUT_TYPE in OUTPUT_TYPES_BUILTIN %}
+			<tr class="row-highlight">
+				<td>
+					<label for="imgur_output_type_{{ OUTPUT_TYPE.KEY }}">
+						<strong>{{ OUTPUT_TYPE.NAME }}</strong>
+					</label>
+					{% if OUTPUT_TYPE.EXPLAIN %}<br><span>{{ OUTPUT_TYPE.EXPLAIN }}</span>{% endif %}
+				</td>
+				<td class="actions">
+					<input type="checkbox" id="imgur_output_type_{{ OUTPUT_TYPE.KEY }}" name="imgur_enabled_output_types[]" value="{{ OUTPUT_TYPE.KEY }}"{% if OUTPUT_TYPE.ENABLED %} checked="checked"{% endif %}>
+				</td>
+				<td class="actions">
+					<input type="radio" name="imgur_output_type" value="{{ OUTPUT_TYPE.KEY }}"{% if IMGUR_OUTPUT_TYPE is same as(OUTPUT_TYPE.KEY) %} checked="checked"{% endif %}>
+				</td>
+			</tr>
+			{% endfor %}
+			{% endif %}
+
+			{% if OUTPUT_TYPES_EXTRAS and OUTPUT_TYPES_EXTRAS is iterable %}
+			<tr class="big-column">
+				<td class="row3 row1" colspan="3">
+					<strong>{{ lang('ACP_IMGUR_OUTPUT_TYPE_EXTRA') }}</strong>
+				</td>
+			</tr>
+			{% for OUTPUT_TYPE in OUTPUT_TYPES_EXTRAS %}
+			<tr class="row-highlight">
+				<td>
+					<label for="imgur_output_type_{{ OUTPUT_TYPE.KEY }}">
+						<strong>{{ OUTPUT_TYPE.NAME }}</strong>
+					</label>
+					{% if OUTPUT_TYPE.EXPLAIN %}<br><span>{{ OUTPUT_TYPE.EXPLAIN }}</span>{% endif %}
+				</td>
+				<td class="actions">
+					<input type="checkbox" id="imgur_output_type_{{ OUTPUT_TYPE.KEY }}" name="imgur_enabled_output_types[]" value="{{ OUTPUT_TYPE.KEY }}"{% if OUTPUT_TYPE.ENABLED %} checked="checked"{% endif %}>
+				</td>
+				<td class="actions">
+					<input type="radio" name="imgur_output_type" value="{{ OUTPUT_TYPE.KEY }}"{% if IMGUR_OUTPUT_TYPE is same as(OUTPUT_TYPE.KEY) %} checked="checked"{% endif %}>
+				</td>
+			</tr>
+			{% endfor %}
+			{% endif %}
+
+		{%- elseif IMGUR_OUTPUT_TYPES and IMGUR_OUTPUT_TYPES is iterable -%}
 
 			{% for OUTPUT_TYPE in IMGUR_OUTPUT_TYPES %}
 			<tr class="row-highlight">
@@ -43,11 +96,11 @@
 			</tr>
 			{% endfor %}
 
-			{%- else -%}
+		{%- else -%}
 			<tr class="big-column">
 				<td colspan="3" style="text-align: center;">{{ lang('ACP_NO_ITEMS') }}</td>
 			</tr>
-			{%- endif -%}
+		{%- endif -%}
 		</tbody>
 	</table>
 	<fieldset class="quick">
@@ -58,6 +111,8 @@
 
 	<hr>
 
+	{%- set THUMBNAILS_NORMAL = IMGUR_THUMBNAIL_SIZES | filter(SIZE => SIZE.KEEP_PROPORTIONS is same as(true)) -%}
+	{%- set THUMBNAILS_SQUARE = IMGUR_THUMBNAIL_SIZES | filter(SIZE => SIZE.KEEP_PROPORTIONS is same as(false)) -%}
 	<div class="errorbox notice">
 		<p>{{ lang('ACP_IMGUR_THUMBNAIL_SIZE_EXPLAIN') }}</p>
 	</div>
@@ -69,9 +124,7 @@
 			</tr>
 		</thead>
 		<tbody>
-			{%- set THUMBNAILS_NORMAL = IMGUR_THUMBNAIL_SIZES | filter(SIZE => SIZE.KEEP_PROPORTIONS is same as(true)) -%}
-			{%- set THUMBNAILS_SQUARE = IMGUR_THUMBNAIL_SIZES | filter(SIZE => SIZE.KEEP_PROPORTIONS is same as(false)) -%}
-			{%- if (THUMBNAILS_NORMAL and THUMBNAILS_NORMAL is iterable) or (THUMBNAILS_SQUARE and THUMBNAILS_SQUARE is iterable) -%}
+		{%- if (THUMBNAILS_NORMAL and THUMBNAILS_NORMAL is iterable) or (THUMBNAILS_SQUARE and THUMBNAILS_SQUARE is iterable) -%}
 
 			{% if THUMBNAILS_NORMAL and THUMBNAILS_NORMAL is iterable %}
 			<tr class="big-column">
@@ -115,7 +168,7 @@
 			{% endfor %}
 			{% endif %}
 
-			{%- elseif IMGUR_THUMBNAIL_SIZES and IMGUR_THUMBNAIL_SIZES is iterable -%}
+		{%- elseif IMGUR_THUMBNAIL_SIZES and IMGUR_THUMBNAIL_SIZES is iterable -%}
 
 			{% for THUMBNAIL_SIZE in IMGUR_THUMBNAIL_SIZES %}
 			<tr class="row-highlight">
@@ -131,11 +184,11 @@
 			</tr>
 			{% endfor %}
 
-			{%- else -%}
+		{%- else -%}
 			<tr class="big-column">
 				<td colspan="3" style="text-align: center;">{{ lang('ACP_NO_ITEMS') }}</td>
 			</tr>
-			{%- endif -%}
+		{%- endif -%}
 		</tbody>
 	</table>
 

--- a/adm/style/acp_imgur_settings.html
+++ b/adm/style/acp_imgur_settings.html
@@ -1,6 +1,7 @@
 {% include 'overall_header.html' %}
 
 <h1>{{ lang('SETTINGS') }}</h1>
+{{ lang('ACP_IMGUR_API_SETTINGS_EXPLAIN') }}
 
 {% if VALIDATION_ERRORS %}
 <div class="errorbox">

--- a/adm/style/css/imgur_acp.css
+++ b/adm/style/css/imgur_acp.css
@@ -39,3 +39,17 @@
 	cursor: pointer;
 	color: #d58512;
 }
+
+.imgur-table th {
+	text-transform: none;
+	font-size: 1em;
+}
+
+.imgur-table th + th {
+	text-align: center;
+}
+
+.imgur-table td > label {
+	font-size: 1em;
+	padding: 0;
+}

--- a/controller/acp.php
+++ b/controller/acp.php
@@ -245,10 +245,10 @@ class acp
 
 		// Markdown options are optional and can be deleted latter,
 		// so they shouldn't be choices to set them as default values
-		$contracts = $this->helper->allowed_imgur_values(null, false);
+		$contracts = $this->helper->allowed_imgur_values();
 
 		// Helper for thumbnails sizes
-		$contracts['thumbnails'] = [
+		$thumbnails = [
 			// Keep image proportions
 			['t', 'm', 'l', 'h'],
 
@@ -256,7 +256,11 @@ class acp
 			['s', 'b'],
 		];
 
-		$enabled = $this->helper->enabled_imgur_values();
+		// Enabled values
+		$enabled = $this->helper->enabled_imgur_values(null, $contracts);
+
+		// Extra values added by extensions
+		$extras = $this->helper->allowed_imgur_values(null, true, true);
 
 		// Validation errors
 		$errors = [];
@@ -374,12 +378,20 @@ class acp
 		// Assign allowed output types
 		foreach ($contracts['types'] as $type)
 		{
-			$this->template->assign_block_vars('IMGUR_OUTPUT_TYPES', [
+			$template_data = [
 				'KEY' => $type,
 				'NAME' => $this->language->lang(sprintf('IMGUR_OUTPUT_%s', strtoupper($type))),
 				'EXPLAIN' => $this->language->lang(sprintf('ACP_IMGUR_OUTPUT_%s_EXPLAIN', strtoupper($type))),
 				'ENABLED' => in_array($type, $enabled['types'], true)
-			]);
+			];
+
+			// Extra values added by extensions
+			if (!empty($extras['types']))
+			{
+				$template_data['EXTRA'] = in_array($type, $extras['types'], true);
+			}
+
+			$this->template->assign_block_vars('IMGUR_OUTPUT_TYPES', $template_data);
 		}
 
 		// Assign allowed thumbnail sizes
@@ -426,7 +438,7 @@ class acp
 				'KEY' => $size,
 				'NAME' => $this->language->lang(sprintf('ACP_IMGUR_THUMBNAIL_%s', $name)),
 				'EXPLAIN' => $this->language->lang(sprintf('ACP_IMGUR_THUMBNAIL_%s_EXPLAIN', $name)),
-				'KEEP_PROPORTIONS' => in_array($size, $contracts['thumbnails'][0], true)
+				'KEEP_PROPORTIONS' => in_array($size, $thumbnails[0], true)
 			]);
 		}
 

--- a/controller/acp.php
+++ b/controller/acp.php
@@ -327,6 +327,13 @@ class acp
 					]);
 				}
 
+				// Can't set as default a disabled option
+				if (!in_array($fields[$data['filter']], $fields[$key]))
+				{
+					// Set as default the first available
+					$fields[$data['filter']] = $fields[$key][0];
+				}
+
 				// Enabled (input) values must be in the allowed values
 				if (!empty(array_diff($fields[$key], $contracts[$data['contract']])))
 				{
@@ -354,7 +361,7 @@ class acp
 				// Save configuration
 				foreach ($fields as $key => $value)
 				{
-					//$this->config->set($key, $value, false);
+					$this->config->set($key, $value, false);
 				}
 
 				// Admin log

--- a/controller/acp.php
+++ b/controller/acp.php
@@ -135,7 +135,8 @@ class acp
 				'token_type'		=> '',
 				'refresh_token'		=> '',
 				'account_id'		=> 0,
-				'account_username'	=> ''
+				'account_username'	=> '',
+				'scope'				=> null
 			];
 
 			// Form data
@@ -157,6 +158,13 @@ class acp
 				// Clear token
 				foreach ($token as $key => $value)
 				{
+					// Scope can be NULL
+					// Configuration table does not allow NULL values
+					if ($key === 'scope')
+					{
+						$value = trim($value);
+					}
+
 					$this->config->set(sprintf('imgur_%s', $key), $value, false);
 				}
 
@@ -243,8 +251,9 @@ class acp
 		$this->language->add_lang('acp/permissions');
 		$this->language->add_lang('posting', 'alfredoramos/imgur');
 
-		// Markdown options are optional and can be deleted latter,
-		// so they shouldn't be choices to set them as default values
+		// Allowed values, including those added by another extensions
+		// They need to be enabled first, and are removed when
+		// that extension is disabled or removed
 		$contracts = $this->helper->allowed_imgur_values();
 
 		// Helper for thumbnails sizes

--- a/controller/acp.php
+++ b/controller/acp.php
@@ -217,10 +217,10 @@ class acp
 		}
 
 		// Assign validation errors
-		foreach ($errors as $key => $value)
+		foreach ($errors as $error)
 		{
 			$this->template->assign_block_vars('VALIDATION_ERRORS', [
-				'MESSAGE' => $value['message']
+				'MESSAGE' => $error['message']
 			]);
 		}
 	}
@@ -419,7 +419,7 @@ class acp
 			// Invalid o not yet supported size
 			if (empty($name))
 			{
-				return;
+				continue;
 			}
 
 			$this->template->assign_block_vars('IMGUR_THUMBNAIL_SIZES', [
@@ -431,10 +431,10 @@ class acp
 		}
 
 		// Assign validation errors
-		foreach ($errors as $key => $value)
+		foreach ($errors as $error)
 		{
 			$this->template->assign_block_vars('VALIDATION_ERRORS', [
-				'MESSAGE' => $value['message']
+				'MESSAGE' => $error['message']
 			]);
 		}
 	}

--- a/controller/imgur.php
+++ b/controller/imgur.php
@@ -103,7 +103,7 @@ class imgur
 	 */
 	public function authorize($hash = '')
 	{
-		// Add translations
+		// Load translations
 		$this->language->add_lang(['controller', 'acp/info_acp_common'], 'alfredoramos/imgur');
 
 		// This route can only be used by admins
@@ -146,7 +146,8 @@ class imgur
 			'token_type'		=> '',
 			'refresh_token'		=> '',
 			'account_id'		=> 0,
-			'account_username'	=> ''
+			'account_username'	=> '',
+			'scope'				=> null
 		];
 
 		// Generate new token

--- a/includes/helper.php
+++ b/includes/helper.php
@@ -201,8 +201,8 @@ class helper
 	/**
 	 * Enabled imgur values for output.
 	 *
-	 * @param string $kind		(optional)
-	 * @param string $allowed	(optional)
+	 * @param string	$kind		(optional)
+	 * @param array		$allowed	(optional)
 	 *
 	 * @return array
 	 */
@@ -265,6 +265,7 @@ class helper
 				$same = $value;
 			}
 
+			// Remove empty values
 			$same = $this->filter_empty_items($same);
 
 			// Configuration name
@@ -285,14 +286,17 @@ class helper
 			$type = array_search('image', $enabled['types']);
 			$type = ($type !== false) ? $enabled['types'][$type] : $enabled['types'][0];
 
+			// Update fallback value
 			$this->config->set('imgur_output_type', $type, false);
 		}
 
+		// Get specific kind
 		if (!empty($kind) && !empty($enabled[$kind]))
 		{
 			return $enabled[$kind];
 		}
 
+		// Return whole array
 		return $enabled;
 	}
 

--- a/includes/helper.php
+++ b/includes/helper.php
@@ -59,28 +59,36 @@ class helper
 	 */
 	public function assign_template_variables()
 	{
+		// Enabled output values
+		$enabled = $this->enabled_imgur_values();
+
+		// Fallback output type
+		if (!in_array($this->config['imgur_output_type'], $enabled['types'], true))
+		{
+			$this->config->set('imgur_output_type', $enabled['types'][0], false);
+		}
+
+		// Fallback thumbnail size
+		if (!in_array($this->config['imgur_thumbnail_size'], $enabled['sizes'], true))
+		{
+			$this->config->set('imgur_thumbnail_size', $enabled['sizes'][0], false);
+		}
+
 		// Assign global template variables
 		$this->template->assign_vars([
-			'IMGUR_UPLOAD_URL'	=> vsprintf('%1$s/%2$s', [
+			'IMGUR_UPLOAD_URL' => vsprintf('%1$s/%2$s', [
 				$this->routing_helper->route('alfredoramos_imgur_upload'),
 				generate_link_hash('imgur_upload')
 			]),
-			'SHOW_IMGUR_BUTTON'	=> !empty($this->config['imgur_access_token']),
+			'SHOW_IMGUR_BUTTON' => !empty($this->config['imgur_access_token']),
 			'IMGUR_OUTPUT_TYPE' => $this->config['imgur_output_type'],
-			'IMGUR_THUMBNAIL_SIZE'	=> $this->config['imgur_thumbnail_size']
+			'IMGUR_THUMBNAIL_SIZE' => $this->config['imgur_thumbnail_size'],
+			'IMGUR_ALLOWED_OUTPUT_TYPES' => implode(',', $enabled['types']),
+			'IMGUR_ALLOWED_THUMBNAIL_SIZES' => implode(',', $enabled['sizes'])
 		]);
 
-		// Enabled output types
-		$types = $this->enabled_imgur_values('types');
-
-		// Fallback to image
-		if (!in_array($this->config['imgur_output_type'], $types, true))
-		{
-			$this->config->set('imgur_output_type', 'image');
-		}
-
 		// Assign enabled output types
-		foreach ($types as $type)
+		foreach ($enabled['types'] as $type)
 		{
 			$this->template->assign_block_vars('IMGUR_ENABLED_OUTPUT_TYPES', [
 				'KEY' => $type,

--- a/includes/helper.php
+++ b/includes/helper.php
@@ -148,6 +148,7 @@ class helper
 			'refresh_token'		=> $this->config['imgur_refresh_token'],
 			'account_id'		=> (int) $this->config['imgur_accound_id'],
 			'account_username'	=> $this->config['imgur_account_username'],
+			'scope'				=> empty($this->config['imgur_scope']) ? null : $this->config['imgur_scope'],
 			'created_at'		=> (int) $this->config['imgur_created_at']
 		];
 	}

--- a/includes/helper.php
+++ b/includes/helper.php
@@ -161,6 +161,48 @@ class helper
 	}
 
 	/**
+	 * Remove empty items from an array, recursively.
+	 *
+	 * @param array		$data
+	 * @param integer	$depth
+	 *
+	 * @return array
+	 */
+	public function filter_empty_items($data = [], $depth = 0)
+	{
+		if (empty($data))
+		{
+			return [];
+		}
+
+		$max_depth = 5;
+		$depth = abs($depth) + 1;
+
+		// Do not go deeper, return data as is
+		if ($depth > $max_depth)
+		{
+			return $data;
+		}
+
+		// Remove empty elements
+		foreach ($data as $key => $value)
+		{
+			if (empty($value))
+			{
+				unset($data[$key]);
+			}
+
+			if (is_array($value) && !empty($value))
+			{
+				$data[$key] = $this->filter_empty_items($data[$key], $depth);
+			}
+		}
+
+		// Return a copy
+		return $data;
+	}
+
+	/**
 	 * Allowed imgur values for output.
 	 *
 	 * @param string	$key	(optional)
@@ -176,7 +218,7 @@ class helper
 			'types' => ['text', 'url', 'image', 'thumbnail'],
 
 			// Thumbnail sizes
-			'sizes'	=> ['t', 'm']
+			'sizes'	=> ['t', 'm', 'l', 'h', 's', 'b',]
 		];
 
 		// Value casting

--- a/includes/helper.php
+++ b/includes/helper.php
@@ -70,8 +70,8 @@ class helper
 			'IMGUR_THUMBNAIL_SIZE'	=> $this->config['imgur_thumbnail_size']
 		]);
 
-		// Allowed output types
-		$types = $this->allowed_imgur_values('types');
+		// Enabled output types
+		$types = $this->enabled_imgur_values('types');
 
 		// Fallback to image
 		if (!in_array($this->config['imgur_output_type'], $types, true))
@@ -79,15 +79,12 @@ class helper
 			$this->config->set('imgur_output_type', 'image');
 		}
 
-		// Assign allowed output types
+		// Assign enabled output types
 		foreach ($types as $type)
 		{
-			$this->template->assign_block_vars('IMGUR_ALLOWED_OUTPUT_TYPES', [
+			$this->template->assign_block_vars('IMGUR_ENABLED_OUTPUT_TYPES', [
 				'KEY' => $type,
-				'NAME' => $this->language->lang(sprintf(
-					'IMGUR_OUTPUT_%s',
-					strtoupper($type)
-				)),
+				'NAME' => $this->language->lang(sprintf('IMGUR_OUTPUT_%s', strtoupper($type))),
 				'DEFAULT' => $this->config['imgur_output_type'] === $type
 			]);
 		}
@@ -200,6 +197,43 @@ class helper
 
 		// Return a copy
 		return $data;
+	}
+
+	/**
+	 * Enabled imgur values for output.
+	 *
+	 * @param string $key (optional)
+	 *
+	 * @return array
+	 */
+	public function enabled_imgur_values($key = '')
+	{
+		$key = trim($key);
+
+		// Enabled options
+		$enabled = [
+			'types' => explode(',', trim($this->config['imgur_enabled_output_types'])),
+			'sizes' => explode(',', trim($this->config['imgur_enabled_thumbnail_sizes']))
+		];
+
+		// Remove empty options
+		$enabled = $this->filter_empty_items($enabled);
+
+		// Administrator must not disable all options
+		foreach ($enabled as $k => $v)
+		{
+			if (empty($v))
+			{
+				$enabled[$k] = $this->allowed_imgur_values($k, false);
+			}
+		}
+
+		if (!empty($key) && !empty($enabled[$key]))
+		{
+			return $enabled[$key];
+		}
+
+		return $enabled;
 	}
 
 	/**

--- a/includes/helper.php
+++ b/includes/helper.php
@@ -175,7 +175,8 @@ class helper
 
 		// Cast values
 		$depth = abs($depth) + 1;
-		$max_depth = !empty($max_depth) ? abs($max_depth) : 5;
+		$max_depth = abs($max_depth);
+		$max_depth = !empty($max_depth) ? $max_depth : 5;
 
 		// Do not go deeper, return data as is
 		if ($depth > $max_depth)

--- a/includes/helper.php
+++ b/includes/helper.php
@@ -158,6 +158,7 @@ class helper
 	 *
 	 * @param array		$data
 	 * @param integer	$depth
+	 * @param integer	$max_depth
 	 *
 	 * @return array
 	 */

--- a/includes/helper.php
+++ b/includes/helper.php
@@ -68,12 +68,6 @@ class helper
 			$this->config->set('imgur_output_type', $enabled['types'][0], false);
 		}
 
-		// Fallback thumbnail size
-		if (!in_array($this->config['imgur_thumbnail_size'], $enabled['sizes'], true))
-		{
-			$this->config->set('imgur_thumbnail_size', $enabled['sizes'][0], false);
-		}
-
 		// Assign global template variables
 		$this->template->assign_vars([
 			'IMGUR_UPLOAD_URL' => vsprintf('%1$s/%2$s', [
@@ -83,8 +77,7 @@ class helper
 			'SHOW_IMGUR_BUTTON' => !empty($this->config['imgur_access_token']),
 			'IMGUR_OUTPUT_TYPE' => $this->config['imgur_output_type'],
 			'IMGUR_THUMBNAIL_SIZE' => $this->config['imgur_thumbnail_size'],
-			'IMGUR_ALLOWED_OUTPUT_TYPES' => implode(',', $enabled['types']),
-			'IMGUR_ALLOWED_THUMBNAIL_SIZES' => implode(',', $enabled['sizes'])
+			'IMGUR_ALLOWED_OUTPUT_TYPES' => implode(',', $enabled['types'])
 		]);
 
 		// Assign enabled output types
@@ -173,15 +166,16 @@ class helper
 	 *
 	 * @return array
 	 */
-	public function filter_empty_items($data = [], $depth = 0)
+	public function filter_empty_items($data = [], $depth = 0, $max_depth = 5)
 	{
 		if (empty($data))
 		{
 			return [];
 		}
 
-		$max_depth = 5;
+		// Cast values
 		$depth = abs($depth) + 1;
+		$max_depth = !empty($max_depth) ? abs($max_depth) : 5;
 
 		// Do not go deeper, return data as is
 		if ($depth > $max_depth)
@@ -220,8 +214,7 @@ class helper
 
 		// Enabled options
 		$enabled = [
-			'types' => explode(',', trim($this->config['imgur_enabled_output_types'])),
-			'sizes' => explode(',', trim($this->config['imgur_enabled_thumbnail_sizes']))
+			'types' => explode(',', trim($this->config['imgur_enabled_output_types']))
 		];
 
 		// Remove empty options

--- a/language/en/acp/settings.php
+++ b/language/en/acp/settings.php
@@ -38,7 +38,7 @@ $lang = array_merge($lang, [
 	'ACP_IMGUR_ALBUM_EXPLAIN' => 'Alphanumeric string with a length equal or greater than 5 characters. It will be used to store the uploaded images. Leave it empty if you want all the images to be uploaded in the default location.',
 	'ACP_IMGUR_ALBUM_DOWNLOAD' => 'Download album backup',
 
-	'ACP_IMGUR_OUTPUT_EXPLAIN' => 'You must select at least one option of each section.',
+	'ACP_IMGUR_OUTPUT_EXPLAIN' => 'You must enable at least one option. Default option must be enabled, otherwise it will use the first available.',
 	'ACP_IMGUR_OUTPUT_TYPE' => 'Output type',
 
 	'ACP_IMGUR_THUMBNAIL_KEEP_PROPORTIONS' => 'Thumbnail sizes that keep image proportions',

--- a/language/en/acp/settings.php
+++ b/language/en/acp/settings.php
@@ -47,16 +47,33 @@ $lang = array_merge($lang, [
 	'ACP_IMGUR_THUMBNAIL_SIZE' => 'Thumbnail size',
 	'ACP_IMGUR_THUMBNAIL_SIZE_EXPLAIN' => '<samp>Thumbnail size</samp> options will not have any effect if the output type is not set to <samp>Thumbnail</samp>.',
 
+	'ACP_IMGUR_OUTPUT_TEXT_EXPLAIN' => 'Raw image URL',
+	'ACP_IMGUR_OUTPUT_URL_EXPLAIN' => '<code>[url]<var>{image}</var>[/url]</code>',
+	'ACP_IMGUR_OUTPUT_IMAGE_EXPLAIN' => '<code>[img]<var>{image}</var>[/img]</code> BBCode',
+	'ACP_IMGUR_OUTPUT_THUMBNAIL_EXPLAIN' => '<code>[url=<var>{image}</var>][img]<var>{thumbnail}</var>[/img][/url]</code>',
+
 	'ACP_IMGUR_THUMBNAIL_SMALL' => 'Small',
+	'ACP_IMGUR_THUMBNAIL_SMALL_EXPLAIN' => '160x160px',
+
 	'ACP_IMGUR_THUMBNAIL_MEDIUM' => 'Medium',
+	'ACP_IMGUR_THUMBNAIL_MEDIUM_EXPLAIN' => '320x320px',
+
 	'ACP_IMGUR_THUMBNAIL_LARGE' => 'Large',
+	'ACP_IMGUR_THUMBNAIL_LARGE_EXPLAIN' => '640x640px',
+
 	'ACP_IMGUR_THUMBNAIL_HUGE' => 'Huge',
+	'ACP_IMGUR_THUMBNAIL_HUGE_EXPLAIN' => '1024x1024px',
+
 	'ACP_IMGUR_THUMBNAIL_SMALL_SQUARE' => 'Small square',
+	'ACP_IMGUR_THUMBNAIL_SMALL_SQUARE_EXPLAIN' => '90x90px',
+
 	'ACP_IMGUR_THUMBNAIL_BIG_SQUARE' => 'Big square',
+	'ACP_IMGUR_THUMBNAIL_BIG_SQUARE_EXPLAIN' => '160x160px',
 
 	'ACP_IMGUR_TOGGLE_DISPLAY_FIELD' => 'Show/Hide %s',
 
-	'ACP_IMGUR_VALIDATE_INVALID_FIELDS' => 'Invalid values for fields: %s',
+	'ACP_IMGUR_VALIDATE_INVALID_FIELDS' => 'Invalid values for fields: <samp>%s</samp>',
+	'ACP_IMGUR_VALIDATE_VALUES_NOT_ALLOWED' => 'The values given for <samp>%1$s</samp> are not allowed: <code>%2$s</code>',
 
 	'OUTPUT_SETTINGS' => 'Output settings'
 ]);

--- a/language/en/acp/settings.php
+++ b/language/en/acp/settings.php
@@ -38,12 +38,21 @@ $lang = array_merge($lang, [
 	'ACP_IMGUR_ALBUM_EXPLAIN' => 'Alphanumeric string with a length equal or greater than 5 characters. It will be used to store the uploaded images. Leave it empty if you want all the images to be uploaded in the default location.',
 	'ACP_IMGUR_ALBUM_DOWNLOAD' => 'Download album backup',
 
+	'ACP_IMGUR_OUTPUT_EXPLAIN' => 'You must select at least one option of each section.',
 	'ACP_IMGUR_OUTPUT_TYPE' => 'Output type',
 
+	'ACP_IMGUR_THUMBNAIL_KEEP_PROPORTIONS' => 'Thumbnail sizes that keep image proportions',
+	'ACP_IMGUR_THUMBNAIL_NOT_KEEP_PROPORTIONS' => 'Thumbnail sizes that do <u>not</u> keep image proportions',
+
 	'ACP_IMGUR_THUMBNAIL_SIZE' => 'Thumbnail size',
-	'ACP_IMGUR_THUMBNAIL_SIZE_EXPLAIN' => 'This setting will not have any effect if the output type is not set to <samp>Thumbnail</samp>. Thumbnail sizes are 160x160 for <samp>Small</samp> and 320x320 for <samp>Medium</samp>, image proportions are kept.',
+	'ACP_IMGUR_THUMBNAIL_SIZE_EXPLAIN' => '<samp>Thumbnail size</samp> options will not have any effect if the output type is not set to <samp>Thumbnail</samp>.',
+
 	'ACP_IMGUR_THUMBNAIL_SMALL' => 'Small',
 	'ACP_IMGUR_THUMBNAIL_MEDIUM' => 'Medium',
+	'ACP_IMGUR_THUMBNAIL_LARGE' => 'Large',
+	'ACP_IMGUR_THUMBNAIL_HUGE' => 'Huge',
+	'ACP_IMGUR_THUMBNAIL_SMALL_SQUARE' => 'Small square',
+	'ACP_IMGUR_THUMBNAIL_BIG_SQUARE' => 'Big square',
 
 	'ACP_IMGUR_TOGGLE_DISPLAY_FIELD' => 'Show/Hide %s',
 

--- a/language/en/acp/settings.php
+++ b/language/en/acp/settings.php
@@ -38,8 +38,8 @@ $lang = array_merge($lang, [
 	'ACP_IMGUR_ALBUM_EXPLAIN' => 'Alphanumeric string with a length equal or greater than 5 characters. It will be used to store the uploaded images. Leave it empty if you want all the images to be uploaded in the default location.',
 	'ACP_IMGUR_ALBUM_DOWNLOAD' => 'Download album backup',
 
-	'ACP_IMGUR_OUTPUT_EXPLAIN' => 'You must enable at least one option. Default option must be enabled, otherwise it will use the first available.',
 	'ACP_IMGUR_OUTPUT_TYPE' => 'Output type',
+	'ACP_IMGUR_OUTPUT_TYPE_EXPLAIN' => 'You must enable at least one option. Default option must be enabled, otherwise it will use the first available.',
 
 	'ACP_IMGUR_THUMBNAIL_KEEP_PROPORTIONS' => 'Thumbnail sizes that keep image proportions',
 	'ACP_IMGUR_THUMBNAIL_NOT_KEEP_PROPORTIONS' => 'Thumbnail sizes that do <u>not</u> keep image proportions',

--- a/language/en/acp/settings.php
+++ b/language/en/acp/settings.php
@@ -30,6 +30,8 @@ $lang = array_merge($lang, [
 	'ACP_IMGUR_AUTHORIZE_EXPLAIN' => 'You need to authorize the application in order to upload the images to your account.',
 
 	'ACP_IMGUR_API_SETTINGS' => 'API settings',
+	'ACP_IMGUR_API_SETTINGS_EXPLAIN' => '<p>Here you can set the required Imgur API data. Consult the <a href="https://www.phpbb.com/customise/db/extension/imgur/faq"><strong>FAQ</strong></a> for more information. If you require assistance, please visit the <a href="https://www.phpbb.com/customise/db/extension/imgur/support"><strong>Support</strong></a> section.</p>',
+
 	'ACP_IMGUR_CLIENT_ID' => 'Client ID',
 	'ACP_IMGUR_CLIENT_ID_EXPLAIN' => 'String consisting of hexadecimal numbers with a length of 15 characters.',
 	'ACP_IMGUR_CLIENT_SECRET' => 'Client Secret',
@@ -38,8 +40,14 @@ $lang = array_merge($lang, [
 	'ACP_IMGUR_ALBUM_EXPLAIN' => 'Alphanumeric string with a length equal or greater than 5 characters. It will be used to store the uploaded images. Leave it empty if you want all the images to be uploaded in the default location.',
 	'ACP_IMGUR_ALBUM_DOWNLOAD' => 'Download album backup',
 
+	'OUTPUT_SETTINGS' => 'Output settings',
+	'OUTPUT_SETTINGS_EXPLAIN' => '<p>Here you can enable, disable and set as default some options that will change the output of the uploaded images. It will also display custom options added by third-party extensions, however, <strong>you will need to enable each custom option in order to use it</strong>.</p>',
+
 	'ACP_IMGUR_OUTPUT_TYPE' => 'Output type',
 	'ACP_IMGUR_OUTPUT_TYPE_EXPLAIN' => 'You must enable at least one option. Default option must be enabled, otherwise it will use the first available.',
+
+	'ACP_IMGUR_OUTPUT_TYPE_BUILTIN' => 'Built-in',
+	'ACP_IMGUR_OUTPUT_TYPE_EXTRA' => 'Provided by other extensions',
 
 	'ACP_IMGUR_THUMBNAIL_KEEP_PROPORTIONS' => 'Thumbnail sizes that keep image proportions',
 	'ACP_IMGUR_THUMBNAIL_NOT_KEEP_PROPORTIONS' => 'Thumbnail sizes that do <u>not</u> keep image proportions',
@@ -49,7 +57,7 @@ $lang = array_merge($lang, [
 
 	'ACP_IMGUR_OUTPUT_TEXT_EXPLAIN' => 'Raw image URL',
 	'ACP_IMGUR_OUTPUT_URL_EXPLAIN' => '<code>[url]<var>{image}</var>[/url]</code>',
-	'ACP_IMGUR_OUTPUT_IMAGE_EXPLAIN' => '<code>[img]<var>{image}</var>[/img]</code> BBCode',
+	'ACP_IMGUR_OUTPUT_IMAGE_EXPLAIN' => '<code>[img]<var>{image}</var>[/img]</code>',
 	'ACP_IMGUR_OUTPUT_THUMBNAIL_EXPLAIN' => '<code>[url=<var>{image}</var>][img]<var>{thumbnail}</var>[/img][/url]</code>',
 
 	'ACP_IMGUR_THUMBNAIL_SMALL' => 'Small',
@@ -73,7 +81,5 @@ $lang = array_merge($lang, [
 	'ACP_IMGUR_TOGGLE_DISPLAY_FIELD' => 'Show/Hide %s',
 
 	'ACP_IMGUR_VALIDATE_INVALID_FIELDS' => 'Invalid values for fields: <samp>%s</samp>',
-	'ACP_IMGUR_VALIDATE_VALUES_NOT_ALLOWED' => 'The values given for <samp>%1$s</samp> are not allowed: <code>%2$s</code>',
-
-	'OUTPUT_SETTINGS' => 'Output settings'
+	'ACP_IMGUR_VALIDATE_VALUES_NOT_ALLOWED' => 'The values given for <samp>%1$s</samp> are not allowed: <code>%2$s</code>'
 ]);

--- a/language/es/acp/settings.php
+++ b/language/es/acp/settings.php
@@ -39,15 +39,41 @@ $lang = array_merge($lang, [
 	'ACP_IMGUR_ALBUM_DOWNLOAD' => 'Descargar copia de seguridad del álbum',
 
 	'ACP_IMGUR_OUTPUT_TYPE' => 'Tipo de salida',
+	'ACP_IMGUR_OUTPUT_TYPE_EXPLAIN' => 'Debe habilitar al menos una opción. La opción por defecto debe estar habilitada, sino se utilizará la primer opción disponible.',
+
+	'ACP_IMGUR_THUMBNAIL_KEEP_PROPORTIONS' => 'Tamaños de miniatura que mantienen las proporciones de la imagen',
+	'ACP_IMGUR_THUMBNAIL_NOT_KEEP_PROPORTIONS' => 'Tamaños de miniatura que <u>no</u> mantienen las proporciones de la imagen',
 
 	'ACP_IMGUR_THUMBNAIL_SIZE' => 'Tamaño de miniatura',
-	'ACP_IMGUR_THUMBNAIL_SIZE_EXPLAIN' => 'Este ajuste no tendrá ningun efecto si el tipo de salida no se establece en <samp>Miniatura</samp>. Los tamaños de las miniaturas son de 160x160 para <samp>Pequeña</samp> y 320x320 para <samp>Mediana</samp>, las proporciones de la imagen son mantenidas.',
+	'ACP_IMGUR_THUMBNAIL_SIZE_EXPLAIN' => 'Este ajuste no tendrá ningun efecto si el tipo de salida no se establece en <samp>Miniatura</samp>.',
+
+	'ACP_IMGUR_OUTPUT_TEXT_EXPLAIN' => 'URL de imagen sin formato',
+	'ACP_IMGUR_OUTPUT_URL_EXPLAIN' => '<code>[url]<var>{imagen}</var>[/url]</code>',
+	'ACP_IMGUR_OUTPUT_IMAGE_EXPLAIN' => '<code>[img]<var>{imagen}</var>[/img]</code> BBCode',
+	'ACP_IMGUR_OUTPUT_THUMBNAIL_EXPLAIN' => '<code>[url=<var>{imagen}</var>][img]<var>{miniatura}</var>[/img][/url]</code>',
+
 	'ACP_IMGUR_THUMBNAIL_SMALL' => 'Pequeña',
+	'ACP_IMGUR_THUMBNAIL_SMALL_EXPLAIN' => '160x160px',
+
 	'ACP_IMGUR_THUMBNAIL_MEDIUM' => 'Mediana',
+	'ACP_IMGUR_THUMBNAIL_MEDIUM_EXPLAIN' => '320x320px',
+
+	'ACP_IMGUR_THUMBNAIL_LARGE' => 'Grande',
+	'ACP_IMGUR_THUMBNAIL_LARGE_EXPLAIN' => '640x640px',
+
+	'ACP_IMGUR_THUMBNAIL_HUGE' => 'Enorme',
+	'ACP_IMGUR_THUMBNAIL_HUGE_EXPLAIN' => '1024x1024px',
+
+	'ACP_IMGUR_THUMBNAIL_SMALL_SQUARE' => 'Cuadrado pequeño',
+	'ACP_IMGUR_THUMBNAIL_SMALL_SQUARE_EXPLAIN' => '90x90px',
+
+	'ACP_IMGUR_THUMBNAIL_BIG_SQUARE' => 'Cuadrado grande',
+	'ACP_IMGUR_THUMBNAIL_BIG_SQUARE_EXPLAIN' => '160x160px',
 
 	'ACP_IMGUR_TOGGLE_DISPLAY_FIELD' => 'Mostrar/Ocultar %s',
 
 	'ACP_IMGUR_VALIDATE_INVALID_FIELDS' => 'Valores inválidos para los campos: %s',
+	'ACP_IMGUR_VALIDATE_VALUES_NOT_ALLOWED' => 'Los valores proporcionados para <samp>%1$s</samp> no estan permitidos: <code>%2$s</code>',
 
 	'OUTPUT_SETTINGS' => 'Ajustes de salida'
 ]);

--- a/language/es/acp/settings.php
+++ b/language/es/acp/settings.php
@@ -30,6 +30,8 @@ $lang = array_merge($lang, [
 	'ACP_IMGUR_AUTHORIZE_EXPLAIN' => 'Necesita autorizar la aplicación para poder subir las imágenes a su cuenta.',
 
 	'ACP_IMGUR_API_SETTINGS' => 'Ajustes de la API',
+	'ACP_IMGUR_API_SETTINGS_EXPLAIN' => '<p>Aquí puede añadir los datos necesarios para la API de Imgur. Consulte las <a href="https://www.phpbb.com/customise/db/extension/imgur/faq"><strong>Preguntas Frecuentes</strong></a> para obtener más información. Si requiere de ayuda, por favor visite la sección de <a href="https://www.phpbb.com/customise/db/extension/imgur/support"><strong>Soporte</strong></a>.</p>',
+
 	'ACP_IMGUR_CLIENT_ID' => '<em>Client ID</em>',
 	'ACP_IMGUR_CLIENT_ID_EXPLAIN' => 'Cadena de texto compuesta por números hexadecimales con una longitud de 15 caracteres.',
 	'ACP_IMGUR_CLIENT_SECRET' => '<em>Client Secret</em>',
@@ -38,8 +40,14 @@ $lang = array_merge($lang, [
 	'ACP_IMGUR_ALBUM_EXPLAIN' => 'Cadena de texto alfanumérico con una longitud igual o mayor a 5 caracteres. Será usado para almacenar las imágenes subidas. Déjelo vacío si desea que las imágenes sean subidas en la ubicación por defecto.',
 	'ACP_IMGUR_ALBUM_DOWNLOAD' => 'Descargar copia de seguridad del álbum',
 
+	'OUTPUT_SETTINGS' => 'Ajustes de salida',
+	'OUTPUT_SETTINGS_EXPLAIN' => '<p>Aquí puede habilitar, deshabilitar y establecer por defecto algunas opciones que cambiarán la salida de las imágenes subidas. También mostrará opciones personalizadas añadidas por extensiones de terceros, sin embargo, <strong>necesitará habilitar cada opción personalizada para poder usarla</strong>.</p>',
+
 	'ACP_IMGUR_OUTPUT_TYPE' => 'Tipo de salida',
 	'ACP_IMGUR_OUTPUT_TYPE_EXPLAIN' => 'Debe habilitar al menos una opción. La opción por defecto debe estar habilitada, sino se utilizará la primer opción disponible.',
+
+	'ACP_IMGUR_OUTPUT_TYPE_BUILTIN' => 'Incluidos',
+	'ACP_IMGUR_OUTPUT_TYPE_EXTRA' => 'Proporcionados por otras extensiones',
 
 	'ACP_IMGUR_THUMBNAIL_KEEP_PROPORTIONS' => 'Tamaños de miniatura que mantienen las proporciones de la imagen',
 	'ACP_IMGUR_THUMBNAIL_NOT_KEEP_PROPORTIONS' => 'Tamaños de miniatura que <u>no</u> mantienen las proporciones de la imagen',
@@ -49,7 +57,7 @@ $lang = array_merge($lang, [
 
 	'ACP_IMGUR_OUTPUT_TEXT_EXPLAIN' => 'URL de imagen sin formato',
 	'ACP_IMGUR_OUTPUT_URL_EXPLAIN' => '<code>[url]<var>{imagen}</var>[/url]</code>',
-	'ACP_IMGUR_OUTPUT_IMAGE_EXPLAIN' => '<code>[img]<var>{imagen}</var>[/img]</code> BBCode',
+	'ACP_IMGUR_OUTPUT_IMAGE_EXPLAIN' => '<code>[img]<var>{imagen}</var>[/img]</code>',
 	'ACP_IMGUR_OUTPUT_THUMBNAIL_EXPLAIN' => '<code>[url=<var>{imagen}</var>][img]<var>{miniatura}</var>[/img][/url]</code>',
 
 	'ACP_IMGUR_THUMBNAIL_SMALL' => 'Pequeña',
@@ -73,7 +81,5 @@ $lang = array_merge($lang, [
 	'ACP_IMGUR_TOGGLE_DISPLAY_FIELD' => 'Mostrar/Ocultar %s',
 
 	'ACP_IMGUR_VALIDATE_INVALID_FIELDS' => 'Valores inválidos para los campos: %s',
-	'ACP_IMGUR_VALIDATE_VALUES_NOT_ALLOWED' => 'Los valores proporcionados para <samp>%1$s</samp> no estan permitidos: <code>%2$s</code>',
-
-	'OUTPUT_SETTINGS' => 'Ajustes de salida'
+	'ACP_IMGUR_VALIDATE_VALUES_NOT_ALLOWED' => 'Los valores proporcionados para <samp>%1$s</samp> no estan permitidos: <code>%2$s</code>'
 ]);

--- a/language/es_x_tu/acp/settings.php
+++ b/language/es_x_tu/acp/settings.php
@@ -30,6 +30,8 @@ $lang = array_merge($lang, [
 	'ACP_IMGUR_AUTHORIZE_EXPLAIN' => 'Necesitas autorizar la aplicación para poder subir las imágenes a tu cuenta.',
 
 	'ACP_IMGUR_API_SETTINGS' => 'Ajustes de la API',
+	'ACP_IMGUR_API_SETTINGS_EXPLAIN' => '<p>Aquí puedes añadir los datos necesarios para la API de Imgur. Consulta las <a href="https://www.phpbb.com/customise/db/extension/imgur/faq"><strong>Preguntas Frecuentes</strong></a> para obtener más información. Si requieres de ayuda, por favor visita la sección de <a href="https://www.phpbb.com/customise/db/extension/imgur/support"><strong>Soporte</strong></a>.</p>',
+
 	'ACP_IMGUR_CLIENT_ID' => '<em>Client ID</em>',
 	'ACP_IMGUR_CLIENT_ID_EXPLAIN' => 'Cadena de texto compuesta por números hexadecimales con una longitud de 15 caracteres.',
 	'ACP_IMGUR_CLIENT_SECRET' => '<em>Client Secret</em>',
@@ -41,6 +43,9 @@ $lang = array_merge($lang, [
 	'ACP_IMGUR_OUTPUT_TYPE' => 'Tipo de salida',
 	'ACP_IMGUR_OUTPUT_TYPE_EXPLAIN' => 'Debes habilitar al menos una opción. La opción por defecto debe estar habilitada, sino se utilizará la primer opción disponible.',
 
+	'ACP_IMGUR_OUTPUT_TYPE_BUILTIN' => 'Incluidos',
+	'ACP_IMGUR_OUTPUT_TYPE_EXTRA' => 'Proporcionados por otras extensiones',
+
 	'ACP_IMGUR_THUMBNAIL_KEEP_PROPORTIONS' => 'Tamaños de miniatura que mantienen las proporciones de la imagen',
 	'ACP_IMGUR_THUMBNAIL_NOT_KEEP_PROPORTIONS' => 'Tamaños de miniatura que <u>no</u> mantienen las proporciones de la imagen',
 
@@ -49,7 +54,7 @@ $lang = array_merge($lang, [
 
 	'ACP_IMGUR_OUTPUT_TEXT_EXPLAIN' => 'URL de imagen sin formato',
 	'ACP_IMGUR_OUTPUT_URL_EXPLAIN' => '<code>[url]<var>{imagen}</var>[/url]</code>',
-	'ACP_IMGUR_OUTPUT_IMAGE_EXPLAIN' => '<code>[img]<var>{imagen}</var>[/img]</code> BBCode',
+	'ACP_IMGUR_OUTPUT_IMAGE_EXPLAIN' => '<code>[img]<var>{imagen}</var>[/img]</code>',
 	'ACP_IMGUR_OUTPUT_THUMBNAIL_EXPLAIN' => '<code>[url=<var>{imagen}</var>][img]<var>{miniatura}</var>[/img][/url]</code>',
 
 	'ACP_IMGUR_THUMBNAIL_SMALL' => 'Pequeña',
@@ -75,5 +80,6 @@ $lang = array_merge($lang, [
 	'ACP_IMGUR_VALIDATE_INVALID_FIELDS' => 'Valores inválidos para los campos: %s',
 	'ACP_IMGUR_VALIDATE_VALUES_NOT_ALLOWED' => 'Los valores proporcionados para <samp>%1$s</samp> no estan permitidos: <code>%2$s</code>',
 
-	'OUTPUT_SETTINGS' => 'Ajustes de salida'
+	'OUTPUT_SETTINGS' => 'Ajustes de salida',
+	'OUTPUT_SETTINGS_EXPLAIN' => '<p>Aquí puedes habilitar, deshabilitar y establecer por defecto algunas opciones que cambiarán la salida de las imágenes subidas. También mostrará opciones personalizadas añadidas por extensiones de terceros, sin embargo, <strong>necesitarás habilitar cada opción personalizada para poder usarla</strong>.</p>',
 ]);

--- a/language/es_x_tu/acp/settings.php
+++ b/language/es_x_tu/acp/settings.php
@@ -39,15 +39,41 @@ $lang = array_merge($lang, [
 	'ACP_IMGUR_ALBUM_DOWNLOAD' => 'Descargar copia de seguridad del álbum',
 
 	'ACP_IMGUR_OUTPUT_TYPE' => 'Tipo de salida',
+	'ACP_IMGUR_OUTPUT_TYPE_EXPLAIN' => 'Debes habilitar al menos una opción. La opción por defecto debe estar habilitada, sino se utilizará la primer opción disponible.',
+
+	'ACP_IMGUR_THUMBNAIL_KEEP_PROPORTIONS' => 'Tamaños de miniatura que mantienen las proporciones de la imagen',
+	'ACP_IMGUR_THUMBNAIL_NOT_KEEP_PROPORTIONS' => 'Tamaños de miniatura que <u>no</u> mantienen las proporciones de la imagen',
 
 	'ACP_IMGUR_THUMBNAIL_SIZE' => 'Tamaño de miniatura',
-	'ACP_IMGUR_THUMBNAIL_SIZE_EXPLAIN' => 'Este ajuste no tendrá ningun efecto si el tipo de salida no se establece en <samp>Miniatura</samp>. Los tamaños de las miniaturas son de 160x160 para <samp>Pequeña</samp> y 320x320 para <samp>Mediana</samp>, las proporciones de la imagen son mantenidas.',
+	'ACP_IMGUR_THUMBNAIL_SIZE_EXPLAIN' => 'Este ajuste no tendrá ningun efecto si el tipo de salida no se establece en <samp>Miniatura</samp>.',
+
+	'ACP_IMGUR_OUTPUT_TEXT_EXPLAIN' => 'URL de imagen sin formato',
+	'ACP_IMGUR_OUTPUT_URL_EXPLAIN' => '<code>[url]<var>{imagen}</var>[/url]</code>',
+	'ACP_IMGUR_OUTPUT_IMAGE_EXPLAIN' => '<code>[img]<var>{imagen}</var>[/img]</code> BBCode',
+	'ACP_IMGUR_OUTPUT_THUMBNAIL_EXPLAIN' => '<code>[url=<var>{imagen}</var>][img]<var>{miniatura}</var>[/img][/url]</code>',
+
 	'ACP_IMGUR_THUMBNAIL_SMALL' => 'Pequeña',
+	'ACP_IMGUR_THUMBNAIL_SMALL_EXPLAIN' => '160x160px',
+
 	'ACP_IMGUR_THUMBNAIL_MEDIUM' => 'Mediana',
+	'ACP_IMGUR_THUMBNAIL_MEDIUM_EXPLAIN' => '320x320px',
+
+	'ACP_IMGUR_THUMBNAIL_LARGE' => 'Grande',
+	'ACP_IMGUR_THUMBNAIL_LARGE_EXPLAIN' => '640x640px',
+
+	'ACP_IMGUR_THUMBNAIL_HUGE' => 'Enorme',
+	'ACP_IMGUR_THUMBNAIL_HUGE_EXPLAIN' => '1024x1024px',
+
+	'ACP_IMGUR_THUMBNAIL_SMALL_SQUARE' => 'Cuadrado pequeño',
+	'ACP_IMGUR_THUMBNAIL_SMALL_SQUARE_EXPLAIN' => '90x90px',
+
+	'ACP_IMGUR_THUMBNAIL_BIG_SQUARE' => 'Cuadrado grande',
+	'ACP_IMGUR_THUMBNAIL_BIG_SQUARE_EXPLAIN' => '160x160px',
 
 	'ACP_IMGUR_TOGGLE_DISPLAY_FIELD' => 'Mostrar/Ocultar %s',
 
 	'ACP_IMGUR_VALIDATE_INVALID_FIELDS' => 'Valores inválidos para los campos: %s',
+	'ACP_IMGUR_VALIDATE_VALUES_NOT_ALLOWED' => 'Los valores proporcionados para <samp>%1$s</samp> no estan permitidos: <code>%2$s</code>',
 
 	'OUTPUT_SETTINGS' => 'Ajustes de salida'
 ]);

--- a/migrations/v13x/m1_imgur_data.php
+++ b/migrations/v13x/m1_imgur_data.php
@@ -38,10 +38,6 @@ class m1_imgur_data extends migration
 			[
 				'config.add',
 				['imgur_enabled_output_types', 'url,image,thumbnail', true]
-			],
-			[
-				'config.add',
-				['imgur_enabled_thumbnail_sizes', 't,m,s,b', true]
 			]
 		];
 	}

--- a/migrations/v13x/m1_imgur_data.php
+++ b/migrations/v13x/m1_imgur_data.php
@@ -37,7 +37,7 @@ class m1_imgur_data extends migration
 			],
 			[
 				'config.add',
-				['imgur_enabled_output_types', 'url,image,thumbnail', true]
+				['imgur_enabled_output_types', '', true]
 			]
 		];
 	}

--- a/migrations/v13x/m1_imgur_data.php
+++ b/migrations/v13x/m1_imgur_data.php
@@ -37,11 +37,11 @@ class m1_imgur_data extends migration
 			],
 			[
 				'config.add',
-				['imgur_enabled_output_types', 'url,image,thumbnail']
+				['imgur_enabled_output_types', 'url,image,thumbnail', true]
 			],
 			[
 				'config.add',
-				['imgur_enabled_thumbnail_sizes', 't,m,s,b']
+				['imgur_enabled_thumbnail_sizes', 't,m,s,b', true]
 			]
 		];
 	}

--- a/migrations/v13x/m1_imgur_data.php
+++ b/migrations/v13x/m1_imgur_data.php
@@ -34,6 +34,14 @@ class m1_imgur_data extends migration
 			[
 				'config.add',
 				['imgur_scope', '', true]
+			],
+			[
+				'config.add',
+				['imgur_enabled_output_types', 'url,image,thumbnail']
+			],
+			[
+				'config.add',
+				['imgur_enabled_thumbnail_sizes', 't,m,s,b']
 			]
 		];
 	}

--- a/styles/all/template/imgur_config.html
+++ b/styles/all/template/imgur_config.html
@@ -1,6 +1,10 @@
 {% if not INCLUDED_IMGUR_CONFIG %}
 <script>
 var $imgur = {
+	config: {
+		types: '{{ IMGUR_ALLOWED_OUTPUT_TYPES|escape("js") }}',
+		sizes: '{{ IMGUR_ALLOWED_THUMBNAIL_SIZES|escape("js") }}'
+	},
 	lang: {
 		error: '{{ lang("ERROR")|escape("js") }}',
 		imageTooBig: '{{ lang("IMGUR_IMAGE_TOO_BIG")|escape("js") }}',

--- a/styles/all/template/imgur_config.html
+++ b/styles/all/template/imgur_config.html
@@ -2,8 +2,7 @@
 <script>
 var $imgur = {
 	config: {
-		types: '{{ IMGUR_ALLOWED_OUTPUT_TYPES|escape("js") }}',
-		sizes: '{{ IMGUR_ALLOWED_THUMBNAIL_SIZES|escape("js") }}'
+		types: '{{ IMGUR_ALLOWED_OUTPUT_TYPES|escape("js") }}'
 	},
 	lang: {
 		error: '{{ lang("ERROR")|escape("js") }}',

--- a/styles/all/theme/js/imgur.js
+++ b/styles/all/theme/js/imgur.js
@@ -337,7 +337,7 @@
 			}
 
 			// Must be allowed
-			if ($output.type.allowed.indexOf($output.type.current) < 0) {
+			if ($output.type.allowed.length > 0 && $output.type.allowed.indexOf($output.type.current) < 0) {
 				$output.type.current = $output.type.allowed[0];
 			}
 

--- a/styles/all/theme/js/imgur.js
+++ b/styles/all/theme/js/imgur.js
@@ -60,7 +60,7 @@
 
 		// Restore user preference
 		if ($imgurStorage.enabled) {
-			if (window.localStorage.getItem($imgurStorage.local) !== null) {
+			if (window.localStorage.getItem($imgurStorage.local) !== 'null') {
 				$imgurButton.attr('data-output-type', window.localStorage.getItem($imgurStorage.local));
 			}
 		}
@@ -140,7 +140,7 @@
 
 				// Remove session data
 				if ($imgurStorage.enabled) {
-					if (window.sessionStorage.getItem($imgurStorage.session) !== null) {
+					if (window.sessionStorage.getItem($imgurStorage.session) !== 'null') {
 						window.sessionStorage.removeItem($imgurStorage.session);
 					}
 				}
@@ -183,7 +183,7 @@
 
 					// Save (and append) data to session
 					if ($imgurStorage.enabled) {
-						if (window.sessionStorage.getItem($imgurStorage.session) !== null) {
+						if (window.sessionStorage.getItem($imgurStorage.session) !== 'null') {
 							$outputList = JSON.parse(window.sessionStorage.getItem($imgurStorage.session));
 						}
 
@@ -323,18 +323,34 @@
 	// Add generated output in posting editor panel
 	try {
 		if ($imgurStorage.enabled) {
+			var $output = {
+				type: {
+					default: $('#imgur-image').attr('data-output-type'),
+					current: window.localStorage.getItem($imgurStorage.local),
+					allowed: $imgur.config.types.split(',')
+				}
+			};
+
+			// Fallback to default
+			if ($output.type.current === 'null') {
+				$output.type.current = $output.type.default;
+			}
+
+			// Must be allowed
+			if ($output.type.allowed.indexOf($output.type.current) < 0) {
+				$output.type.current = $output.type.allowed[0];
+			}
+
 			// Restore user preference
 			if ($('.imgur-output-select').length > 0 &&
-				window.localStorage.getItem($imgurStorage.local) !== null) {
-				$('.imgur-output-select').val(
-					window.localStorage.getItem($imgurStorage.local)
-				);
+				window.localStorage.getItem($imgurStorage.local) !== 'null') {
+				$('.imgur-output-select').val($output.type.current);
 				$('.imgur-output-select').trigger('change');
 			}
 
 			// Delete output if page doesn't have the fields to do so
 			if ($('#imgur-panel .imgur-output-field').length <= 0 &&
-				window.sessionStorage.getItem($imgurStorage.session) !== null) {
+				window.sessionStorage.getItem($imgurStorage.session) !== 'null') {
 				window.sessionStorage.removeItem($imgurStorage.session);
 				return;
 			}

--- a/styles/prosilver/template/abbc3_imgur_posting_button.html
+++ b/styles/prosilver/template/abbc3_imgur_posting_button.html
@@ -1,9 +1,9 @@
 {% if IMGUR_UPLOAD_URL and SHOW_IMGUR_BUTTON %}
 <div class="imgur-wrapper">
 	<input type="button" class="imgur-button abbc3_button" title="{{ lang('IMGUR_BUTTON_EXPLAIN')|striptags|escape }}">
-	{% if IMGUR_ALLOWED_OUTPUT_TYPES %}
+	{% if IMGUR_ENABLED_OUTPUT_TYPES %}
 	<select class="imgur-output-select" role="menu">
-		{% for OUTPUT_TYPE in IMGUR_ALLOWED_OUTPUT_TYPES %}
+		{% for OUTPUT_TYPE in IMGUR_ENABLED_OUTPUT_TYPES %}
 		<option value="{{ OUTPUT_TYPE.KEY }}" role="menuitem"{% if OUTPUT_TYPE.DEFAULT %} selected="selected"{% endif %}>
 		{{ OUTPUT_TYPE.NAME }}
 		</option>

--- a/styles/prosilver/template/imgur_posting_button.html
+++ b/styles/prosilver/template/imgur_posting_button.html
@@ -3,9 +3,9 @@
 	<button type="button" class="imgur-button button button-icon-only bbcode-color" title="{{ lang('IMGUR_BUTTON_EXPLAIN')|striptags|escape }}">
 		<span class="icon"></span>
 	</button>
-	{% if IMGUR_ALLOWED_OUTPUT_TYPES %}
+	{% if IMGUR_ENABLED_OUTPUT_TYPES %}
 	<select class="imgur-output-select" role="menu">
-		{% for OUTPUT_TYPE in IMGUR_ALLOWED_OUTPUT_TYPES %}
+		{% for OUTPUT_TYPE in IMGUR_ENABLED_OUTPUT_TYPES %}
 		<option value="{{ OUTPUT_TYPE.KEY }}" role="menuitem"{% if OUTPUT_TYPE.DEFAULT %} selected="selected"{% endif %}>
 		{{ OUTPUT_TYPE.NAME }}
 		</option>

--- a/styles/prosilver/template/imgur_posting_editor_tab_body.html
+++ b/styles/prosilver/template/imgur_posting_editor_tab_body.html
@@ -5,9 +5,9 @@
 			<span class="icon"></span> {{ lang('IMGUR_UPLOAD') }}
 		</button>
 		<p>{{ lang('IMGUR_PANEL_BUTTON_EXPLAIN') }}</p>
-		{% if IMGUR_ALLOWED_OUTPUT_TYPES %}
+		{% if IMGUR_ENABLED_OUTPUT_TYPES %}
 		<fieldset class="imgur-output-fields fields2">
-			{% for OUTPUT_TYPE in IMGUR_ALLOWED_OUTPUT_TYPES %}
+			{% for OUTPUT_TYPE in IMGUR_ENABLED_OUTPUT_TYPES %}
 			<dl class="hidden">
 				<dt>
 					<label for="imgur_output_{{ OUTPUT_TYPE.KEY }}">{{ OUTPUT_TYPE.NAME }}</label>

--- a/tests/functional/acp_imgur_test.php
+++ b/tests/functional/acp_imgur_test.php
@@ -63,11 +63,12 @@ class acp_imgur_test extends abstract_functional_test_case
 		$this->assertTrue($form->has('imgur_enabled_output_types'));
 		$this->assertSame(4, count($form->get('imgur_enabled_output_types')));
 
+		var_dump($form->get('imgur_enabled_output_types'));
+
 		foreach ($allowed['types'] as $key => $value)
 		{
 			$selector = sprintf('#imgur_output_settings #imgur_output_type_%s', $value);
 			$this->assertSame(1, $crawler->filter($selector)->count());
-			$this->assertSame($value, $form['imgur_enabled_output_types'][$key]->getValue());
 		}
 
 		$this->assertTrue($form->has('imgur_output_type'));

--- a/tests/functional/acp_imgur_test.php
+++ b/tests/functional/acp_imgur_test.php
@@ -51,9 +51,26 @@ class acp_imgur_test extends abstract_functional_test_case
 			$this->sid
 		));
 
+		$allowed = [
+			'types' => ['text', 'url', 'image', 'thumbnail'],
+			'sizes' => ['t', 'm', 'l', 'h', 's', 'b']
+		];
+
 		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
 
 		$this->assertSame(1, $crawler->filter('#imgur_output_settings')->count());
+
+		$this->assertTrue($form->has('imgur_enabled_output_types[]'));
+		$this->assertSame(4, $crawler->filter(
+			sprintf('#imgur_output_settings [name="imgur_enabled_output_types[]"]')
+		)->count());
+
+		foreach ($allowed['types'] as $key => $value)
+		{
+			$selector = sprintf('#imgur_output_settings #imgur_output_type_%s', $type);
+			$this->assertSame(1, $crawler->filter($selector));
+			$this->assertSame($value, $form->get('imgur_enabled_output_types')[$key]->getValue());
+		}
 
 		$this->assertTrue($form->has('imgur_output_type'));
 		$this->assertSame('image', $form->get('imgur_output_type')->getValue());

--- a/tests/functional/acp_imgur_test.php
+++ b/tests/functional/acp_imgur_test.php
@@ -60,14 +60,12 @@ class acp_imgur_test extends abstract_functional_test_case
 
 		$this->assertSame(1, $crawler->filter('#imgur_output_settings')->count());
 
-		$this->assertTrue($form->has('imgur_enabled_output_types[]'));
-		$this->assertSame(4, $crawler->filter(
-			sprintf('#imgur_output_settings [name="imgur_enabled_output_types[]"]')
-		)->count());
+		$this->assertTrue($form->has('imgur_enabled_output_types'));
+		$this->assertSame(4, count($form->get('imgur_enabled_output_types')));
 
 		foreach ($allowed['types'] as $key => $value)
 		{
-			$selector = sprintf('#imgur_output_settings #imgur_output_type_%s', $type);
+			$selector = sprintf('#imgur_output_settings #imgur_output_type_%s', $value);
 			$this->assertSame(1, $crawler->filter($selector));
 			$this->assertSame($value, $form->get('imgur_enabled_output_types')[$key]->getValue());
 		}

--- a/tests/functional/acp_imgur_test.php
+++ b/tests/functional/acp_imgur_test.php
@@ -63,14 +63,6 @@ class acp_imgur_test extends abstract_functional_test_case
 		$this->assertTrue($form->has('imgur_enabled_output_types'));
 		$this->assertSame(4, count($form->get('imgur_enabled_output_types')));
 
-		foreach ($form->get('imgur_enabled_output_types') as $key => $value)
-		{
-			$this->assertTrue($value->containsOption(
-				$allowed['types'][$key],
-				$allowed['types']
-			));
-		}
-
 		foreach ($allowed['types'] as $key => $value)
 		{
 			$selector = sprintf('#imgur_output_settings #imgur_output_type_%s', $value);

--- a/tests/functional/acp_imgur_test.php
+++ b/tests/functional/acp_imgur_test.php
@@ -63,7 +63,10 @@ class acp_imgur_test extends abstract_functional_test_case
 		$this->assertTrue($form->has('imgur_enabled_output_types'));
 		$this->assertSame(4, count($form->get('imgur_enabled_output_types')));
 
-		var_dump($form->get('imgur_enabled_output_types'));
+		foreach ($form->get('imgur_enabled_output_types') as $key => $value)
+		{
+			$this->assertTrue($value->containsOption($allowed[$key]));
+		}
 
 		foreach ($allowed['types'] as $key => $value)
 		{

--- a/tests/functional/acp_imgur_test.php
+++ b/tests/functional/acp_imgur_test.php
@@ -61,12 +61,13 @@ class acp_imgur_test extends abstract_functional_test_case
 		$this->assertSame(1, $crawler->filter('#imgur_output_settings')->count());
 
 		$this->assertTrue($form->has('imgur_enabled_output_types'));
+		$this->assertSame(4, count($form->get('imgur_enabled_output_types')));
 
 		foreach ($allowed['types'] as $key => $value)
 		{
 			$selector = sprintf('#imgur_output_settings #imgur_output_type_%s', $value);
 			$this->assertSame(1, $crawler->filter($selector)->count());
-			$this->assertSame($value, $form->get('imgur_enabled_output_types')[$key]->getValue());
+			$this->assertSame($value, $form['imgur_enabled_output_types'][$key]->getValue());
 		}
 
 		$this->assertTrue($form->has('imgur_output_type'));

--- a/tests/functional/acp_imgur_test.php
+++ b/tests/functional/acp_imgur_test.php
@@ -65,7 +65,10 @@ class acp_imgur_test extends abstract_functional_test_case
 
 		foreach ($form->get('imgur_enabled_output_types') as $key => $value)
 		{
-			$this->assertTrue($value->containsOption($allowed[$key]));
+			$this->assertTrue($value->containsOption(
+				$allowed['types'][$key],
+				$allowed['types']
+			));
 		}
 
 		foreach ($allowed['types'] as $key => $value)

--- a/tests/functional/acp_imgur_test.php
+++ b/tests/functional/acp_imgur_test.php
@@ -61,12 +61,11 @@ class acp_imgur_test extends abstract_functional_test_case
 		$this->assertSame(1, $crawler->filter('#imgur_output_settings')->count());
 
 		$this->assertTrue($form->has('imgur_enabled_output_types'));
-		$this->assertSame(4, count($form->get('imgur_enabled_output_types')));
 
 		foreach ($allowed['types'] as $key => $value)
 		{
 			$selector = sprintf('#imgur_output_settings #imgur_output_type_%s', $value);
-			$this->assertSame(1, $crawler->filter($selector));
+			$this->assertSame(1, $crawler->filter($selector)->count());
 			$this->assertSame($value, $form->get('imgur_enabled_output_types')[$key]->getValue());
 		}
 

--- a/tests/functional/acp_imgur_test.php
+++ b/tests/functional/acp_imgur_test.php
@@ -63,9 +63,9 @@ class acp_imgur_test extends abstract_functional_test_case
 		$this->assertTrue($form->has('imgur_enabled_output_types'));
 		$this->assertSame(4, count($form->get('imgur_enabled_output_types')));
 
-		foreach ($allowed['types'] as $key => $value)
+		foreach ($allowed['types'] as $type)
 		{
-			$selector = sprintf('#imgur_output_settings #imgur_output_type_%s', $value);
+			$selector = sprintf('#imgur_output_settings #imgur_output_type_%s', $type);
 			$this->assertSame(1, $crawler->filter($selector)->count());
 		}
 

--- a/tests/functional/imgur_test.php
+++ b/tests/functional/imgur_test.php
@@ -65,6 +65,6 @@ class imgur_test extends abstract_functional_test_case
 			$elements['upload']->text()
 		);
 
-		$this->assertSame(4, $elements['fields']->count());
+		$this->assertSame(3, $elements['fields']->count());
 	}
 }

--- a/tests/functional/imgur_test.php
+++ b/tests/functional/imgur_test.php
@@ -65,6 +65,6 @@ class imgur_test extends abstract_functional_test_case
 			$elements['upload']->text()
 		);
 
-		$this->assertSame(3, $elements['fields']->count());
+		$this->assertSame(4, $elements['fields']->count());
 	}
 }


### PR DESCRIPTION
- [x] Allow administrator to disable some output types
- [x] Show output types and thumbnail sizes in tables, with explanation of each option
- [x] Add JavaScript validation of enabled output types
- [x] Add extra thumbnail sizes:
	- [x] Large
	- [x] Huge
	- [x] Small square
	- [x] Big square
- [x] Fix localStorage checks
- [x] Update translations
- [x] Update functional tests
- [x] Code cleanup

Fixes #14 