### PR TITLE
Limit push GitHub Actions CI to master branch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,14 @@
-name: CI
+name: GitHub Actions CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
 
 jobs:
   build:


### PR DESCRIPTION
- [x] Limit `push` to `master` branch only
- [x] Use default `types` for `pull_request`

References:
- https://help.github.com/en/articles/events-that-trigger-workflows#pull-request-event-pull_request