### PR TITLE
Fix template conditions

### DIFF
--- a/styles/all/template/event/ext_quickreply_editor_buttons_custom_tags_before.html
+++ b/styles/all/template/event/ext_quickreply_editor_buttons_custom_tags_before.html
@@ -1,1 +1,3 @@
+{% if IMGUR_UPLOAD_URL and SHOW_IMGUR_BUTTON %}
 {% include '@alfredoramos_imgur/imgur_posting_button.html' ignore missing %}
+{% endif %}

--- a/styles/all/template/event/posting_editor_add_panel_tab.html
+++ b/styles/all/template/event/posting_editor_add_panel_tab.html
@@ -1,1 +1,3 @@
+{% if IMGUR_UPLOAD_URL and SHOW_IMGUR_BUTTON %}
 {% include '@alfredoramos_imgur/imgur_posting_editor_tab.html' ignore missing %}
+{% endif %}

--- a/styles/all/template/event/posting_editor_buttons_custom_tags_before.html
+++ b/styles/all/template/event/posting_editor_buttons_custom_tags_before.html
@@ -1,1 +1,3 @@
+{% if IMGUR_UPLOAD_URL and SHOW_IMGUR_BUTTON %}
 {% include '@alfredoramos_imgur/imgur_posting_button.html' ignore missing %}
+{% endif %}

--- a/styles/all/template/event/posting_layout_include_panel_body.html
+++ b/styles/all/template/event/posting_layout_include_panel_body.html
@@ -1,1 +1,3 @@
+{% if IMGUR_UPLOAD_URL and SHOW_IMGUR_BUTTON %}
 {% include '@alfredoramos_imgur/imgur_posting_editor_tab_body.html' ignore missing %}
+{% endif %}

--- a/styles/all/template/event/vse_abbc3_posting_editor_buttons_custom_tags_before.html
+++ b/styles/all/template/event/vse_abbc3_posting_editor_buttons_custom_tags_before.html
@@ -1,1 +1,3 @@
+{% if IMGUR_UPLOAD_URL and SHOW_IMGUR_BUTTON %}
 {% include '@alfredoramos_imgur/abbc3_imgur_posting_button.html' ignore missing %}
+{% endif %}

--- a/styles/prosilver/template/abbc3_imgur_posting_button.html
+++ b/styles/prosilver/template/abbc3_imgur_posting_button.html
@@ -1,4 +1,3 @@
-{% if IMGUR_UPLOAD_URL and SHOW_IMGUR_BUTTON %}
 <div class="imgur-wrapper">
 	<input type="button" class="imgur-button abbc3_button" title="{{ lang('IMGUR_BUTTON_EXPLAIN')|striptags|escape }}">
 	{% if IMGUR_ENABLED_OUTPUT_TYPES %}
@@ -11,4 +10,3 @@
 	</select>
 	{% endif %}
 </div>
-{% endif %}

--- a/styles/prosilver/template/imgur_posting_button.html
+++ b/styles/prosilver/template/imgur_posting_button.html
@@ -1,4 +1,3 @@
-{% if IMGUR_UPLOAD_URL and SHOW_IMGUR_BUTTON %}
 <div class="imgur-wrapper">
 	<button type="button" class="imgur-button button button-icon-only bbcode-color" title="{{ lang('IMGUR_BUTTON_EXPLAIN')|striptags|escape }}">
 		<span class="icon"></span>
@@ -13,4 +12,3 @@
 	</select>
 	{% endif %}
 </div>
-{% endif %}

--- a/styles/prosilver/template/imgur_posting_editor_tab.html
+++ b/styles/prosilver/template/imgur_posting_editor_tab.html
@@ -1,5 +1,3 @@
-{% if IMGUR_UPLOAD_URL and SHOW_IMGUR_BUTTON %}
 <li id="imgur-panel-tab" class="tab">
 	<a href="#tabs" data-subpanel="imgur-panel" role="tab" aria-controls="imgur-panel">{{ lang('IMGUR_TAB') }}</a>
 </li>
-{% endif %}

--- a/styles/prosilver/template/imgur_posting_editor_tab_body.html
+++ b/styles/prosilver/template/imgur_posting_editor_tab_body.html
@@ -1,4 +1,3 @@
-{% if IMGUR_UPLOAD_URL and SHOW_IMGUR_BUTTON %}
 <div class="panel bg3 panel-container" id="imgur-panel">
 	<div class="inner">
 		<button type="button" class="imgur-button imgur-upload-button" data-add-output="false">
@@ -24,4 +23,3 @@
 		{% endif %}
 	</div>
 </div>
-{% endif %}


### PR DESCRIPTION
The conditions should be in the template files inside `all` directory since they're evaluated on all styles.

Having them in the files from the `prosilver` directory would cause that styles that don't inherit from prosilver to load those template files regardless if they must not be included.