### PR TITLE
Small fixes and improvements in fillOutputFields() function

### DIFF
--- a/styles/all/theme/js/functions.js
+++ b/styles/all/theme/js/functions.js
@@ -178,6 +178,11 @@ function fillOutputFields() {
 
 	const allowed = window.imgur.config.types.split(',');
 
+	// Allowed output types must not be empty
+	if (allowed.length <= 0) {
+		return;
+	}
+
 	// Cleanup
 	document.body.querySelectorAll('[name^="imgur_output_"]').forEach(function(item) {
 		if (!item) {

--- a/styles/all/theme/js/functions.js
+++ b/styles/all/theme/js/functions.js
@@ -131,7 +131,7 @@ function getOutputType() {
 	}
 
 	let current = window.localStorage.getItem(window.imgur.storage.local);
-	let allowed = window.imgur.config.types.split(',');
+	const allowed = window.imgur.config.types.split(',');
 
 	// Fallback to default
 	if (current === 'null' || current === null) {
@@ -176,6 +176,8 @@ function fillOutputFields() {
 		return;
 	}
 
+	const allowed = window.imgur.config.types.split(',');
+
 	// Cleanup
 	document.body.querySelectorAll('[name^="imgur_output_"]').forEach(function(item) {
 		if (!item) {
@@ -185,28 +187,43 @@ function fillOutputFields() {
 		item.value = '';
 	});
 
+	// Fill fields
 	output.forEach(function(item) {
 		if (!item) {
 			return;
 		}
 
-		let key = item[0];
-		let value = item[1];
-		let field = document.body.querySelector('[name="imgur_output_' + key + '"]');
+		for (let key in item) {
+			// Fill only allowed output types
+			if (allowed.indexOf(key) < 0) {
+				continue;
+			}
 
-		if (!field) {
+			let value = item[key];
+			let field = document.body.querySelector('[name="imgur_output_' + key + '"]');
+
+			if (!field) {
+				return;
+			}
+
+			field.value = field.value.trim();
+			value = value.trim();
+
+			if (value.length <= 0) {
+				return;
+			}
+
+			field.value += (field.value.length > 0 ? '\n' : '') + value;
+		}
+	});
+
+	// Trigger change event only once
+	allowed.forEach(function(item) {
+		if (!item) {
 			return;
 		}
 
-		field.value = field.value.trim();
-		value = value.trim();
-
-		if (value.length <= 0) {
-			return;
-		}
-
-		field.value += (field.value.length > 0 ? '\n' : '') + value;
-
+		let field = document.body.querySelector('[name="imgur_output_' + item + '"]');
 		let evt;
 
 		// IE11 fix
@@ -376,6 +393,7 @@ function uploadImagesToImgur(files, args) {
 	// Success
 	xhr.addEventListener('load', function(e) {
 		let outputList = [];
+
 		try {
 			// Get response
 			let rawResponse = e.target.responseText;
@@ -454,7 +472,8 @@ function uploadImagesToImgur(files, args) {
 				output.thumbnail = '[url=' + image.link + '][img]'
 					+ image.thumbnail + '[/img][/url]';
 
-				outputList = outputList.concat(Object.entries(output));
+				// Append output
+				outputList.push(output);
 
 				// Generate BBCode
 				if (output.hasOwnProperty(outputType)) {


### PR DESCRIPTION
- [x] Store output list in an array of objects, which reduces the size stored in `sessionStorage` (fixes #57)
- [x] Verify if the stored output type is allowed before the field is filled (fixes #59)
- [x] Fire `change` event on output fields only once (fixes #58)
- [x] Code cleanup